### PR TITLE
Fix fail test, Change env injection method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set Yaml
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: ./api/src/main/resources/application.yml
+        run: envsubst < ${{ env.YAML_FILE_PATH }} > ${{ env.YAML_FILE_PATH }}.tmp && mv ${{ env.YAML_FILE_PATH }}.tmp ${{ env.YAML_FILE_PATH }}
         env:
-          spring.datasource.url: ${{ secrets.DB_URL }}
-          spring.datasource.username: ${{ secrets.DB_USERNAME }}
-          spring.datasource.password: ${{ secrets.DB_PASSWORD }}
-          ncloud.accessKey: ${{ secrets.NCP_ACCESS_KEY }}
-          ncloud.secretKey: ${{ secrets.NCP_SECRET_KEY }}
+          YAML_FILE_PATH: ./api/src/main/resources/application.yml
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          NCP_ACCESS_KEY: ${{ secrets.NCP_ACCESS_KEY }}
+          NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      
 
 jobs:
   push_to_registry:

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     implementation project(':infra')
 }
 
-jar{
-    enabled=false
+jar {
+    enabled = false
 }

--- a/api/src/main/java/com/nexters/gaetteok/ApiApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/ApiApplication.java
@@ -2,8 +2,10 @@ package com.nexters.gaetteok;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ApiApplication {
   public static void main(String[] args) {
     SpringApplication.run(ApiApplication.class, args);

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -5,12 +5,12 @@ spring:
     hibernate:
       ddl-auto: update
   datasource:
-    url: ${{ secrets.DB_URL }}
-    username: ${{ secrets.DB_USERNAME }}
-    password: ${{ secrets.DB_PASSWORD }}
+    url: ${DB_URL:jdbc:mysql://localhost:3306/gaetteok?useSSL=false&allowPublicKeyRetrieval=true}
+    username: ${DB_USERNAME:gaetteok}
+    password: ${DB_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
 ncloud:
-  accessKey: ${{ secrets.NCP_ACCESS_KEY }}
-  secretKey: ${{ secrets.NCP_SECRET_KEY }}
+  accessKey: ${NCP_ACCESS_KEY}
+  secretKey: ${NCP_SECRET_KEY}
   bucketName: gaetteok-image

--- a/api/src/test/java/com/nexters/gaetteok/ApiApplicationTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/ApiApplicationTests.java
@@ -2,7 +2,9 @@ package com.nexters.gaetteok;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ApiApplicationTests {
 

--- a/api/src/test/resources/application-test.yaml
+++ b/api/src/test/resources/application-test.yaml
@@ -1,5 +1,5 @@
 spring:
-  datasource :
+  datasource:
     url: jdbc:h2:mem:test
     driverClassName: org.h2.Driver
     username: sa

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.765')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
+}
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
- 실패하는 테스트를 성공시키기 위한 의존성 추가, 프로필 활성화, 필요한 어노테이션 추가
- 사소한 포맷 수정
- 환경변수 주입 방법 변경
  - yaml 파일이 github action 표현식 ${{ }}에 의존하게 되는 부분을 해결하고자, 환경 변수를 설정하고 이를 치환하는 라이브러리를 이용하도록 변경
- GitHub 워크플로우 수동 실행을 위한 dispatch 트리거 추가
  - 현재 push 이벤트 발생 시에만 CI/CD 플로우가 동작하므로 merge 이전에 코드 내 문제를 인지할 수 없다는 문제가 있음. (추후 PR 생성됐을 때 테스트가 통과하는지 검증하는 동작 추가 필요)

(+ PR 머지 시 해당 브랜치가 remote에서 자동 제거되는 옵션 활성화해서 해당 PR부터 머지된 브랜치 제거됨)