### PR TITLE
Fix issue where gradle setup fails due to boot attempts by the infrastructure module

### DIFF
--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -6,3 +6,7 @@ dependencies {
 jar {
     enabled = false
 }
+
+bootJar {
+    enabled = false
+}


### PR DESCRIPTION
- infra gradle 파일 생성에 의해 infra 모듈의 bootJar가 실행되어 빌드가 터지는 문제 해결