### PR TITLE
Add fix for deployment errors

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    database-platform: org.hibernate.dialect.MySQL8Dialect
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/domain/user/build.gradle
+++ b/domain/user/build.gradle
@@ -1,5 +1,5 @@
 jar {
-    enabled = false
+    enabled = true
 }
 
 bootJar {


### PR DESCRIPTION
- dialect 설정 누락으로 db 연동에 실패하던 문제 해결
- 도메인 모듈은 다른 모듈에서 의존하는 모듈이므로 jar 설정을 enabled = true로 설정