### PR TITLE
Fix API document generation, Assume a mock user

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Gradle
         run: |
           chmod +x gradlew
-          ./gradlew build -x test
+          ./gradlew build
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/FriendController.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/FriendController.java
@@ -20,14 +20,14 @@ public class FriendController {
 
     @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CreateFriendResponse> create(@RequestBody CreateFriendRequest request) {
-        // TODO 토큰에서 꺼내온 사용자 고유값. 현재 로그인 기능 미구현으로 임시값 사용
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
         long userId = 1L;
         return ResponseEntity.ok(CreateFriendResponse.of(friendApplication.create(userId, request.getCode())));
     }
 
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GetFriendListResponse> getList() {
-        // TODO 토큰에서 꺼내온 사용자 고유값. 현재 로그인 기능 미구현으로 임시값 사용
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
         long userId = 1L;
         return ResponseEntity.ok(GetFriendListResponse.of(friendApplication.getMyFriendList(userId)));
     }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/UserController.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/UserController.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,9 +18,11 @@ public class UserController {
 
     private final UserApplication userApplication;
 
-    @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<GetUserResponse> getUser(@PathVariable long id) {
-        return ResponseEntity.ok(GetUserResponse.of(userApplication.getUser(id)));
+    @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetUserResponse> getUser() {
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
+        long userId = 1;
+        return ResponseEntity.ok(GetUserResponse.of(userApplication.getUser(userId)));
     }
 
 }

--- a/api/src/test/java/com/nexters/gaetteok/user/presentation/UserControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/user/presentation/UserControllerTests.java
@@ -1,34 +1,21 @@
 package com.nexters.gaetteok.user.presentation;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.gaetteok.common.presentation.AbstractControllerTests;
 import com.nexters.gaetteok.domain.User;
-import com.nexters.gaetteok.user.application.UserApplication;
-import java.time.LocalDateTime;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 
 public class UserControllerTests extends AbstractControllerTests {
@@ -48,7 +35,7 @@ public class UserControllerTests extends AbstractControllerTests {
 
         // when
         ResultActions resultActions = mockMvc.perform(
-            RestDocumentationRequestBuilders.get("/api/users/{id}", id)
+            RestDocumentationRequestBuilders.get("/api/users", id)
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(user)));
 
@@ -61,9 +48,6 @@ public class UserControllerTests extends AbstractControllerTests {
                 resource(ResourceSnippetParameters.builder()
                     .tag("User")
                     .summary("사용자 정보 조회 API")
-                    .pathParameters(
-                        parameterWithName("id").description("사용자 ID")
-                    )
                     .responseFields(
                         fieldWithPath("id").description("사용자 ID"),
                         fieldWithPath("nickname").description("사용자 닉네임"),


### PR DESCRIPTION
- 테스트가 안 돌면 스니펫을 안 만들어서 openapi 문서가 제대로 생성이 안 됨. 빌드 과정에서 테스트 제외 설정을 제거
- 회원가입 구현을 후순위로 미뤘기 때문에, 일단 모든 API는 컨트롤러 동작 시점에 호출자 userId를 알고 있다고 가정 (앞단에서 토큰에서 꺼냈든 세션을 조회했든 뭔가를 해서 주입해준다고 가정)
- 사용자 데이터를 요구하는 모든 API는 userId=1인 사용자가 API를 호출한다고 가정하여 구현