### PR TITLE
Add APIs for feed, Inject test data

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     implementation project(':infra')
     implementation project(':domain:user')
+    implementation project(':domain:walklog')
 }
 
 tasks.named('test') {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,7 +44,8 @@ tasks.named('asciidoctor') {
 
 openapi3 {
     servers = [
-            { url = 'http://localhost:8080' },
+            { url = 'http://175.106.99.165:80'; description = 'Production 문서용' },
+            { url = 'http://localhost:8080'; description = 'Local 테스트용' }
     ]
     title = 'Pawpaw 백엔드 API Docs'
     description = '멍멍이 산책 기록 서비스 Pawpaw 의 API 문서 페이지입니다.'

--- a/api/src/main/java/com/nexters/gaetteok/common/config/TestDataConfig.java
+++ b/api/src/main/java/com/nexters/gaetteok/common/config/TestDataConfig.java
@@ -1,0 +1,36 @@
+package com.nexters.gaetteok.common.config;
+
+import com.nexters.gaetteok.common.service.TestDataInjector;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableScheduling
+@Slf4j
+public class TestDataConfig {
+
+    private final TestDataInjector testDataInjector;
+
+    @PostConstruct
+    public void init() {
+        testDataInjector.initTestData();
+    }
+
+    @Scheduled(cron = "0 0 6 * * ?")
+    public void poppyWalk() {
+        log.info("오전 6시 뽀삐의 가짜 산책");
+        testDataInjector.fakeWalk(1L);
+    }
+
+    @Scheduled(cron = "0 0 14 * * ?")
+    public void chocoWalk() {
+        log.info("오후 2시 초코의 가짜 산책");
+        testDataInjector.fakeWalk(2L);
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/common/service/TestDataInjector.java
+++ b/api/src/main/java/com/nexters/gaetteok/common/service/TestDataInjector.java
@@ -1,0 +1,111 @@
+package com.nexters.gaetteok.common.service;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.domain.WalkTime;
+import com.nexters.gaetteok.persistence.entity.FriendEntity;
+import com.nexters.gaetteok.persistence.entity.UserEntity;
+import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+import com.nexters.gaetteok.user.mapper.FriendMapper;
+import com.nexters.gaetteok.user.mapper.UserMapper;
+import com.nexters.gaetteok.walklog.mapper.WalkLogMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TestDataInjector {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    @Transactional
+    public void initTestData() {
+        log.info("테스트 데이터 주입 - 실제 운영 시점에는 해당 코드는 제거되어야 함");
+
+        UserEntity poppy = entityManager.merge(UserEntity.builder()
+                .nickname("뽀삐")
+                .profileUrl("https://placehold.co/400.png")
+                .code("1a2b3c")
+                .build());
+        UserEntity choco = entityManager.merge(UserEntity.builder()
+                .nickname("초코")
+                .profileUrl("https://placehold.co/400.png")
+                .code("4d5e6f")
+                .build());
+        UserEntity happy = entityManager.merge(UserEntity.builder()
+                .nickname("해피")
+                .profileUrl("https://placehold.co/400.png")
+                .code("7g8h9i")
+                .build());
+        log.info("사용자 데이터 주입 뽀삐={} 초코={} 해피={}", UserMapper.toDomain(poppy), UserMapper.toDomain(choco), UserMapper.toDomain(happy));
+
+        FriendEntity poppyToChoco = entityManager.merge(FriendEntity.builder()
+                .myUserId(poppy.getId())
+                .friendUserId(choco.getId())
+                .build());
+        FriendEntity chocoToPoppy = entityManager.merge(FriendEntity.builder()
+                .myUserId(choco.getId())
+                .friendUserId(poppy.getId())
+                .build());
+        FriendEntity poppyToHappy = entityManager.merge(FriendEntity.builder()
+                .myUserId(poppy.getId())
+                .friendUserId(happy.getId())
+                .build());
+        FriendEntity happyToPoppy = entityManager.merge(FriendEntity.builder()
+                .myUserId(happy.getId())
+                .friendUserId(poppy.getId())
+                .build());
+        log.info("친구 관계 생성 poppy-choco={} poppy-happy={}", FriendMapper.toDomain(poppyToChoco, poppy, choco), FriendMapper.toDomain(poppyToChoco, poppy, happy));
+
+        List<WalkLog> walkLogList = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            WalkLogEntity walkLogEntity = entityManager.merge(WalkLogEntity.builder()
+                    .userId(poppy.getId())
+                    .photoUrl("https://placehold.co/400.png")
+                    .title("산책 끝~")
+                    .content("오늘 산책 짱 재밌었당")
+                    .walkTime(WalkTime.BETWEEN_20_AND_40_MINUTES)
+                    .createdAt(LocalDateTime.now().minusDays(20-i))
+                    .build());
+            walkLogList.add(WalkLogMapper.toDomain(walkLogEntity, poppy));
+        }
+        log.info("뽀삐 산책 기록 저장: {}", walkLogList);
+
+        WalkLogEntity chocoWalkLog = entityManager.merge(WalkLogEntity.builder()
+                .userId(choco.getId())
+                .photoUrl("https://placehold.co/400.png")
+                .title("나두 산책했더")
+                .content("날씨 개좋아")
+                .walkTime(WalkTime.BETWEEN_20_AND_40_MINUTES)
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .build());
+        log.info("초코 산책 기록 저장: {}", chocoWalkLog);
+
+        log.info("테스트 데이터 주입 완료");
+    }
+
+    /**
+     * 가짜 산책
+     */
+    @Transactional
+    public void fakeWalk(long userId) {
+        entityManager.merge(WalkLogEntity.builder()
+                .userId(userId)
+                .photoUrl("https://placehold.co/400.png")
+                .title("가짜 산책")
+                .content("오늘의 가짜 산책 인증~ Good")
+                .walkTime(WalkTime.WITHIN_20_MINUTES)
+                .createdAt(LocalDateTime.now())
+                .build());
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/user/application/FriendApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/application/FriendApplication.java
@@ -1,6 +1,7 @@
 package com.nexters.gaetteok.user.application;
 
 import com.nexters.gaetteok.domain.Friend;
+import com.nexters.gaetteok.domain.FriendWalkStatus;
 import com.nexters.gaetteok.persistence.entity.FriendEntity;
 import com.nexters.gaetteok.persistence.entity.UserEntity;
 import com.nexters.gaetteok.persistence.repository.FriendRepository;
@@ -9,6 +10,7 @@ import com.nexters.gaetteok.user.mapper.FriendMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,6 +43,10 @@ public class FriendApplication {
         List<Long> friendIdList = friendList.stream().map(FriendEntity::getFriendUserId).toList();
         Map<Long, UserEntity> friendUserMap = userRepository.findAllById(friendIdList).stream().collect(Collectors.toMap(UserEntity::getId, e -> e));
         return friendList.stream().map(friend -> FriendMapper.toDomain(friend, user, friendUserMap.get(friend.getFriendUserId()))).toList();
+    }
+
+    public List<FriendWalkStatus> getWalkStatusList(long userId) {
+        return friendRepository.getFriendWalkStatus(userId, LocalDate.now());
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/application/FriendApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/application/FriendApplication.java
@@ -21,24 +21,26 @@ public class FriendApplication {
     private final FriendRepository friendRepository;
 
     public Friend create(long userId, String code) {
-        UserEntity me = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다. userId: " + userId));
-        UserEntity friendUser = userRepository.findByCode(code)
+        UserEntity me = userRepository.getById(userId);
+        UserEntity friend = userRepository.findByCode(code)
                 .orElseThrow(() -> new IllegalArgumentException("해당 친구 코드를 가진 사용자가 존재하지 않습니다. code: " + code));
-        FriendEntity friend = friendRepository.save(FriendEntity.builder()
+        FriendEntity meToFriend = friendRepository.save(FriendEntity.builder()
                 .myUserId(me.getId())
-                .friendUserId(friendUser.getId())
+                .friendUserId(friend.getId())
                 .build());
-        return FriendMapper.toDomain(friend, me, friendUser);
+        FriendEntity friendToMe = friendRepository.save(FriendEntity.builder()
+                .myUserId(friend.getId())
+                .friendUserId(me.getId())
+                .build());
+        return FriendMapper.toDomain(meToFriend, me, friend);
     }
 
     public List<Friend> getMyFriendList(long userId) {
-        UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다. userId: " + userId));
+        UserEntity user = userRepository.getById(userId);
         List<FriendEntity> friendList = friendRepository.findByMyUserId(user.getId());
         List<Long> friendIdList = friendList.stream().map(FriendEntity::getFriendUserId).toList();
         Map<Long, UserEntity> friendUserMap = userRepository.findAllById(friendIdList).stream().collect(Collectors.toMap(UserEntity::getId, e -> e));
-        return friendList.stream().map(friend -> FriendMapper.toDomain(friend, user, friendUserMap.get(friend.getId()))).toList();
+        return friendList.stream().map(friend -> FriendMapper.toDomain(friend, user, friendUserMap.get(friend.getFriendUserId()))).toList();
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/application/UserApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/application/UserApplication.java
@@ -6,7 +6,7 @@ import com.nexters.gaetteok.persistence.entity.UserEntity;
 import com.nexters.gaetteok.persistence.entity.UserPushNotificationEntity;
 import com.nexters.gaetteok.persistence.repository.UserPushNotificationRepository;
 import com.nexters.gaetteok.persistence.repository.UserRepository;
-import java.time.LocalDateTime;
+import com.nexters.gaetteok.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,20 +23,6 @@ public class UserApplication {
             userPushNotificationDomain.getId(),
             userPushNotificationDomain.getUserId(),
             userPushNotificationDomain.getPushNotificationTime()
-        );
-    }
-
-    private User toUserDomain(
-        UserEntity userEntity,
-        UserPushNotificationEntity userPushNotificationEntity
-    ) {
-        return new User(
-            userEntity.getId(),
-            null,
-            null,
-            null,
-            LocalDateTime.now(),
-            toUserPushNotificationDomain(userPushNotificationEntity)
         );
     }
 
@@ -57,7 +43,8 @@ public class UserApplication {
     }
 
     public User getUser(long id) {
-        return null;
+        UserEntity userEntity = userRepository.getById(id);
+        return UserMapper.toDomain(userEntity);
     }
 
     public void updatePushNotificationTime(long id, long timeToBeUpdated) {

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/FriendController.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/FriendController.java
@@ -1,10 +1,12 @@
 package com.nexters.gaetteok.user.presentation;
 
 import com.nexters.gaetteok.domain.Friend;
+import com.nexters.gaetteok.domain.FriendWalkStatus;
 import com.nexters.gaetteok.user.application.FriendApplication;
 import com.nexters.gaetteok.user.presentation.request.CreateFriendRequest;
 import com.nexters.gaetteok.user.presentation.response.CreateFriendResponse;
 import com.nexters.gaetteok.user.presentation.response.GetFriendListResponse;
+import com.nexters.gaetteok.user.presentation.response.GetFriendWalkStatusListResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -37,6 +39,14 @@ public class FriendController {
         long userId = 1L;
         List<Friend> friendList = friendApplication.getMyFriendList(userId);
         return ResponseEntity.ok(GetFriendListResponse.of(friendList));
+    }
+
+    @GetMapping(value = "/walk-status", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetFriendWalkStatusListResponse> getWalkStatusList() {
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
+        long userId = 1L;
+        List<FriendWalkStatus> friendWalkStatusList = friendApplication.getWalkStatusList(userId);
+        return ResponseEntity.ok(new GetFriendWalkStatusListResponse(friendWalkStatusList));
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/FriendController.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/FriendController.java
@@ -1,5 +1,6 @@
 package com.nexters.gaetteok.user.presentation;
 
+import com.nexters.gaetteok.domain.Friend;
 import com.nexters.gaetteok.user.application.FriendApplication;
 import com.nexters.gaetteok.user.presentation.request.CreateFriendRequest;
 import com.nexters.gaetteok.user.presentation.response.CreateFriendResponse;
@@ -9,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -22,14 +25,18 @@ public class FriendController {
     public ResponseEntity<CreateFriendResponse> create(@RequestBody CreateFriendRequest request) {
         // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
         long userId = 1L;
-        return ResponseEntity.ok(CreateFriendResponse.of(friendApplication.create(userId, request.getCode())));
+        log.info("[친구 관계 생성] userId={}, request={}", userId, request);
+        Friend friend = friendApplication.create(userId, request.getCode());
+        log.info("[친구 관계 생성 완료] friend={}", friend);
+        return ResponseEntity.ok(CreateFriendResponse.of(friend));
     }
 
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GetFriendListResponse> getList() {
         // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
         long userId = 1L;
-        return ResponseEntity.ok(GetFriendListResponse.of(friendApplication.getMyFriendList(userId)));
+        List<Friend> friendList = friendApplication.getMyFriendList(userId);
+        return ResponseEntity.ok(GetFriendListResponse.of(friendList));
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/request/CreateFriendRequest.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/request/CreateFriendRequest.java
@@ -3,9 +3,11 @@ package com.nexters.gaetteok.user.presentation.request;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
 public class CreateFriendRequest {
 
     private String code;

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/response/CreateFriendResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/response/CreateFriendResponse.java
@@ -7,18 +7,22 @@ import lombok.Getter;
 @Getter
 public class CreateFriendResponse {
 
+    private long friendId;
+
     private String friendNickname;
 
     private String friendProfileUrl;
 
     @Builder
-    public CreateFriendResponse(String friendNickname, String friendProfileUrl) {
+    public CreateFriendResponse(long friendId, String friendNickname, String friendProfileUrl) {
+        this.friendId = friendId;
         this.friendNickname = friendNickname;
         this.friendProfileUrl = friendProfileUrl;
     }
 
     public static CreateFriendResponse of(Friend friend) {
         return CreateFriendResponse.builder()
+            .friendId(friend.getFriend().getId())
             .friendNickname(friend.getFriend().getNickname())
             .friendProfileUrl(friend.getFriend().getProfileUrl())
             .build();

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendListResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendListResponse.java
@@ -1,5 +1,6 @@
 package com.nexters.gaetteok.user.presentation.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nexters.gaetteok.domain.Friend;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ import java.util.List;
 @Getter
 public class GetFriendListResponse {
 
+    @JsonProperty("items")
     private List<GetFriendResponse> friendList;
 
     public GetFriendListResponse(List<GetFriendResponse> friendList) {

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendResponse.java
@@ -7,18 +7,22 @@ import lombok.Getter;
 @Getter
 public class GetFriendResponse {
 
+    private long id;
+
     private String nickname;
 
     private String profileUrl;
 
     @Builder
-    public GetFriendResponse(String nickname, String profileUrl) {
+    public GetFriendResponse(long id, String nickname, String profileUrl) {
+        this.id = id;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
     }
 
     public static GetFriendResponse of(Friend friend) {
         return GetFriendResponse.builder()
+                .id(friend.getFriend().getId())
                 .nickname(friend.getFriend().getNickname())
                 .profileUrl(friend.getFriend().getProfileUrl())
                 .build();

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendWalkStatusListResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendWalkStatusListResponse.java
@@ -1,0 +1,17 @@
+package com.nexters.gaetteok.user.presentation.response;
+
+import com.nexters.gaetteok.domain.FriendWalkStatus;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetFriendWalkStatusListResponse {
+
+    List<FriendWalkStatus> friendWalkStatusList;
+
+    public GetFriendWalkStatusListResponse(List<FriendWalkStatus> friendWalkStatusList) {
+        this.friendWalkStatusList = friendWalkStatusList;
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendWalkStatusListResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/response/GetFriendWalkStatusListResponse.java
@@ -1,5 +1,6 @@
 package com.nexters.gaetteok.user.presentation.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nexters.gaetteok.domain.FriendWalkStatus;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ import java.util.List;
 @Getter
 public class GetFriendWalkStatusListResponse {
 
+    @JsonProperty("items")
     List<FriendWalkStatus> friendWalkStatusList;
 
     public GetFriendWalkStatusListResponse(List<FriendWalkStatus> friendWalkStatusList) {

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,7 +43,7 @@ public class WalkLogApplication {
         return WalkLogMapper.toDomain(walkLog, me);
     }
 
-    public List<WalkLog> getMyList(long userId, long cursorId, int pageSize) {
+    public List<WalkLog> getListById(long userId, long cursorId, int pageSize) {
         UserEntity me = userRepository.getById(userId);
         return walkLogRepository.getMyList(userId, cursorId, pageSize).stream()
                 .map(walkLogEntity -> WalkLogMapper.toDomain(walkLogEntity, me))
@@ -52,7 +51,7 @@ public class WalkLogApplication {
     }
 
     public List<WalkLog> getList(long userId, long cursorId, int pageSize) {
-        return walkLogRepository.getList(userId, cursorId, pageSize, LocalDate.now());
+        return walkLogRepository.getList(userId, cursorId, pageSize);
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -48,6 +49,10 @@ public class WalkLogApplication {
         return walkLogRepository.getMyList(userId, cursorId, pageSize).stream()
                 .map(walkLogEntity -> WalkLogMapper.toDomain(walkLogEntity, me))
                 .toList();
+    }
+
+    public List<WalkLog> getList(long userId, long cursorId, int pageSize) {
+        return walkLogRepository.getList(userId, cursorId, pageSize, LocalDate.now());
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -1,0 +1,53 @@
+package com.nexters.gaetteok.walklog.application;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.image.model.File;
+import com.nexters.gaetteok.image.service.ImageUploader;
+import com.nexters.gaetteok.persistence.entity.UserEntity;
+import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+import com.nexters.gaetteok.persistence.repository.UserRepository;
+import com.nexters.gaetteok.persistence.repository.WalkLogRepository;
+import com.nexters.gaetteok.walklog.mapper.WalkLogMapper;
+import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WalkLogApplication {
+
+    private final ImageUploader imageUploader;
+    private final UserRepository userRepository;
+    private final WalkLogRepository walkLogRepository;
+
+    public WalkLog create(long userId, CreateWalkLogRequest request, MultipartFile photo) throws IOException {
+        long startTime = System.currentTimeMillis();
+        File file = imageUploader.uploadFiles(Collections.singletonList(photo), "/walk-log/images").get(0);
+        log.info("파일 업로드 완료 (소요 시간: {})", System.currentTimeMillis() - startTime);
+
+        UserEntity me = userRepository.getById(userId);
+        WalkLogEntity walkLog = walkLogRepository.save(WalkLogEntity.builder()
+                .photoUrl(file.getUploadFileUrl())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .walkTime(request.getWalkTime())
+                .userId(userId)
+                .build());
+        return WalkLogMapper.toDomain(walkLog, me);
+    }
+
+    public List<WalkLog> getMyList(long userId, long cursorId, int pageSize) {
+        UserEntity me = userRepository.getById(userId);
+        return walkLogRepository.getMyList(userId, cursorId, pageSize).stream()
+                .map(walkLogEntity -> WalkLogMapper.toDomain(walkLogEntity, me))
+                .toList();
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/mapper/WalkLogMapper.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/mapper/WalkLogMapper.java
@@ -1,0 +1,22 @@
+package com.nexters.gaetteok.walklog.mapper;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.persistence.entity.UserEntity;
+import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+
+public class WalkLogMapper {
+
+    public static WalkLog toDomain(WalkLogEntity entity, UserEntity writer) {
+        return WalkLog.builder()
+                .id(entity.getId())
+                .photoUrl(entity.getPhotoUrl())
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .walkTime(entity.getWalkTime())
+                .writerNickname(writer.getNickname())
+                .writerProfileUrl(writer.getProfileUrl())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -43,4 +43,13 @@ public class WalkLogController {
         return ResponseEntity.ok(GetWalkLogListResponse.of(walkLogList));
     }
 
+    @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetWalkLogListResponse> getList(@RequestParam(defaultValue = "0") long cursorId,
+                                                          @RequestParam(defaultValue = "10") int pageSize) {
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
+        long userId = 1;
+        List<WalkLog> walkLogList = walkLogApplication.getList(userId, cursorId, pageSize);
+        return ResponseEntity.ok(GetWalkLogListResponse.of(walkLogList));
+    }
+
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -1,0 +1,46 @@
+package com.nexters.gaetteok.walklog.presentation;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.walklog.application.WalkLogApplication;
+import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
+import com.nexters.gaetteok.walklog.presentation.response.CreateWalkLogResponse;
+import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/walk-logs")
+@RequiredArgsConstructor
+public class WalkLogController {
+
+    private final WalkLogApplication walkLogApplication;
+
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CreateWalkLogResponse> create(@RequestPart CreateWalkLogRequest request,
+                                                        @RequestPart(name = "photo") MultipartFile photo) throws IOException {
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
+        long userId = 1;
+        log.info("[산책 기록 생성] userId={}, request={}, hasPhoto={}", userId, request, !photo.isEmpty());
+        WalkLog walkLog = walkLogApplication.create(userId, request, photo);
+        log.info("[산책 기록 생성 완료] walkLog={}", walkLog);
+        return ResponseEntity.ok(CreateWalkLogResponse.of(walkLog));
+    }
+
+    @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GetWalkLogListResponse> getMyList(@RequestParam(defaultValue = "0") long cursorId,
+                                                            @RequestParam(defaultValue = "10") int pageSize) {
+        // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
+        long userId = 1;
+        List<WalkLog> walkLogList = walkLogApplication.getMyList(userId, cursorId, pageSize);
+        return ResponseEntity.ok(GetWalkLogListResponse.of(walkLogList));
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -39,16 +39,23 @@ public class WalkLogController {
                                                             @RequestParam(defaultValue = "10") int pageSize) {
         // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
         long userId = 1;
-        List<WalkLog> walkLogList = walkLogApplication.getMyList(userId, cursorId, pageSize);
+        List<WalkLog> walkLogList = walkLogApplication.getListById(userId, cursorId, pageSize);
         return ResponseEntity.ok(GetWalkLogListResponse.of(walkLogList));
     }
 
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<GetWalkLogListResponse> getList(@RequestParam(defaultValue = "0") long cursorId,
+    public ResponseEntity<GetWalkLogListResponse> getList(@RequestParam(required = false, defaultValue = "0") long userId,
+                                                          @RequestParam(defaultValue = "0") long cursorId,
                                                           @RequestParam(defaultValue = "10") int pageSize) {
         // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
-        long userId = 1;
-        List<WalkLog> walkLogList = walkLogApplication.getList(userId, cursorId, pageSize);
+        List<WalkLog> walkLogList;
+        if (userId > 0) {
+            walkLogList = walkLogApplication.getListById(userId, cursorId, pageSize);
+        } else {
+            // TODO 헤더 내 토큰에서 꺼내온 사용자 식별값. 현재 로그인 기능 미구현으로 임시값 사용
+            userId = 1;
+            walkLogList = walkLogApplication.getList(userId, cursorId, pageSize);
+        }
         return ResponseEntity.ok(GetWalkLogListResponse.of(walkLogList));
     }
 

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/request/CreateWalkLogRequest.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/request/CreateWalkLogRequest.java
@@ -1,0 +1,23 @@
+package com.nexters.gaetteok.walklog.presentation.request;
+
+import com.nexters.gaetteok.domain.WalkTime;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class CreateWalkLogRequest {
+
+    private String title;
+
+    private String content;
+
+    private WalkTime walkTime;
+
+    public CreateWalkLogRequest(String title, String content, WalkTime walkTime) {
+        this.title = title;
+        this.content = content;
+        this.walkTime = walkTime;
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/CreateWalkLogResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/CreateWalkLogResponse.java
@@ -1,0 +1,56 @@
+package com.nexters.gaetteok.walklog.presentation.response;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.domain.WalkTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class CreateWalkLogResponse {
+
+    private final long id;
+
+    private final String photoUrl;
+
+    private String title;
+
+    private final String content;
+
+    private final WalkTime walkTime;
+
+    private final String writerNickname;
+
+    private final String writerProfileUrl;
+
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public CreateWalkLogResponse(long id, String photoUrl, String title, String content, WalkTime walkTime, String writerNickname, String writerProfileUrl, LocalDateTime createdAt) {
+        this.id = id;
+        this.photoUrl = photoUrl;
+        this.title = title;
+        this.content = content;
+        this.walkTime = walkTime;
+        this.writerNickname = writerNickname;
+        this.writerProfileUrl = writerProfileUrl;
+        this.createdAt = createdAt;
+    }
+
+    public static CreateWalkLogResponse of(WalkLog walkLog) {
+        return CreateWalkLogResponse.builder()
+                .id(walkLog.getId())
+                .photoUrl(walkLog.getPhotoUrl())
+                .title(walkLog.getTitle())
+                .content(walkLog.getContent())
+                .walkTime(walkLog.getWalkTime())
+                .writerNickname(walkLog.getWriterNickname())
+                .writerProfileUrl(walkLog.getWriterProfileUrl())
+                .createdAt(walkLog.getCreatedAt())
+                .build();
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogListResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogListResponse.java
@@ -1,0 +1,21 @@
+package com.nexters.gaetteok.walklog.presentation.response;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GetWalkLogListResponse {
+
+    private List<GetWalkLogResponse> walkLogList;
+
+    public GetWalkLogListResponse(List<GetWalkLogResponse> walkLogList) {
+        this.walkLogList = walkLogList;
+    }
+
+    public static GetWalkLogListResponse of(List<WalkLog> walkLogList) {
+        return new GetWalkLogListResponse(walkLogList.stream().map(GetWalkLogResponse::of).toList());
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogListResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogListResponse.java
@@ -1,5 +1,6 @@
 package com.nexters.gaetteok.walklog.presentation.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nexters.gaetteok.domain.WalkLog;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ import java.util.List;
 @Getter
 public class GetWalkLogListResponse {
 
+    @JsonProperty("items")
     private List<GetWalkLogResponse> walkLogList;
 
     public GetWalkLogListResponse(List<GetWalkLogResponse> walkLogList) {

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogResponse.java
@@ -1,0 +1,54 @@
+package com.nexters.gaetteok.walklog.presentation.response;
+
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.domain.WalkTime;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class GetWalkLogResponse {
+
+    private long id;
+
+    private String photoUrl;
+
+    private String title;
+
+    private String content;
+
+    private WalkTime walkTime;
+
+    private String writerNickname;
+
+    private String writerProfileUrl;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public GetWalkLogResponse(long id, String photoUrl, String title, String content, WalkTime walkTime, String writerNickname, String writerProfileUrl, LocalDateTime createdAt) {
+        this.id = id;
+        this.photoUrl = photoUrl;
+        this.title = title;
+        this.content = content;
+        this.walkTime = walkTime;
+        this.writerNickname = writerNickname;
+        this.writerProfileUrl = writerProfileUrl;
+        this.createdAt = createdAt;
+    }
+
+    public static GetWalkLogResponse of(WalkLog walkLog) {
+        return GetWalkLogResponse.builder()
+                .id(walkLog.getId())
+                .photoUrl(walkLog.getPhotoUrl())
+                .title(walkLog.getTitle())
+                .content(walkLog.getContent())
+                .walkTime(walkLog.getWalkTime())
+                .writerNickname(walkLog.getWriterNickname())
+                .writerProfileUrl(walkLog.getWriterProfileUrl())
+                .createdAt(walkLog.getCreatedAt())
+                .build();
+    }
+
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: gaetteok
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop # 샘플 데이터 세팅을 위한 임시 조치 (FE에서 데이터 넣기 시작하면 빠져야 함)
     database-platform: org.hibernate.dialect.MySQL8Dialect
   datasource:
     url: ${DB_URL}

--- a/api/src/test/java/com/nexters/gaetteok/common/presentation/AbstractControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/common/presentation/AbstractControllerTests.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.gaetteok.image.service.ImageUploader;
 import com.nexters.gaetteok.user.application.FriendApplication;
 import com.nexters.gaetteok.user.application.UserApplication;
+import com.nexters.gaetteok.walklog.application.WalkLogApplication;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,9 @@ public class AbstractControllerTests {
 
     @MockBean
     protected FriendApplication friendApplication;
+
+    @MockBean
+    protected WalkLogApplication walkLogApplication;
 
     @MockBean
     protected ImageUploader imageUploader;

--- a/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
@@ -4,6 +4,7 @@ import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.nexters.gaetteok.common.presentation.AbstractControllerTests;
 import com.nexters.gaetteok.domain.Friend;
+import com.nexters.gaetteok.domain.FriendWalkStatus;
 import com.nexters.gaetteok.domain.User;
 import com.nexters.gaetteok.user.presentation.request.CreateFriendRequest;
 import org.junit.jupiter.api.Test;
@@ -111,6 +112,45 @@ public class FriendControllerTests extends AbstractControllerTests {
                                 .responseFields(
                                         fieldWithPath("friendList[0].nickname").description("친구의 닉네임"),
                                         fieldWithPath("friendList[0].profileUrl").description("친구의 프로필 이미지 URL")
+                                )
+                                .build())
+                ));
+    }
+
+    @Test
+    void getWalkStatusList_correctId_success() throws Exception {
+        // given
+        FriendWalkStatus walkStatus = FriendWalkStatus.builder()
+                .nickname("뽀삐")
+                .profileUrl("https://profile-image.jpg")
+                .done(true)
+                .build();
+        FriendWalkStatus walkStatus2 = FriendWalkStatus.builder()
+                .nickname("초코")
+                .profileUrl("https://profile-image.jpg")
+                .done(false)
+                .build();
+        List<FriendWalkStatus> walkStatusList = List.of(walkStatus, walkStatus2);
+        given(friendApplication.getWalkStatusList(anyLong())).willReturn(walkStatusList);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/friends/walk-status")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document(
+                        "내 친구들의 오늘 산책 완료 여부 조회",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Friend")
+                                .summary("내 친구들의 오늘 산책 완료 여부를 조회 API")
+                                .responseFields(
+                                        fieldWithPath("friendWalkStatusList[0].nickname").description("친구의 닉네임"),
+                                        fieldWithPath("friendWalkStatusList[0].profileUrl").description("친구의 프로필 이미지 URL"),
+                                        fieldWithPath("friendWalkStatusList[0].done").description("친구의 오늘 산책 완료 여부")
                                 )
                                 .build())
                 ));

--- a/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
@@ -111,9 +111,9 @@ public class FriendControllerTests extends AbstractControllerTests {
                                 .tag("Friend")
                                 .summary("내 친구 목록을 조회하는 API")
                                 .responseFields(
-                                        fieldWithPath("friendList[0].id").description("친구의 아이디"),
-                                        fieldWithPath("friendList[0].nickname").description("친구의 닉네임"),
-                                        fieldWithPath("friendList[0].profileUrl").description("친구의 프로필 이미지 URL")
+                                        fieldWithPath("items[0].id").description("친구의 아이디"),
+                                        fieldWithPath("items[0].nickname").description("친구의 닉네임"),
+                                        fieldWithPath("items[0].profileUrl").description("친구의 프로필 이미지 URL")
                                 )
                                 .build())
                 ));
@@ -152,10 +152,10 @@ public class FriendControllerTests extends AbstractControllerTests {
                                 .tag("Friend")
                                 .summary("내 친구들의 오늘 산책 완료 여부를 조회 API")
                                 .responseFields(
-                                        fieldWithPath("friendWalkStatusList[0].id").description("친구의 아이디"),
-                                        fieldWithPath("friendWalkStatusList[0].nickname").description("친구의 닉네임"),
-                                        fieldWithPath("friendWalkStatusList[0].profileUrl").description("친구의 프로필 이미지 URL"),
-                                        fieldWithPath("friendWalkStatusList[0].done").description("친구의 오늘 산책 완료 여부")
+                                        fieldWithPath("items[0].id").description("친구의 아이디"),
+                                        fieldWithPath("items[0].nickname").description("친구의 닉네임"),
+                                        fieldWithPath("items[0].profileUrl").description("친구의 프로필 이미지 URL"),
+                                        fieldWithPath("items[0].done").description("친구의 오늘 산책 완료 여부")
                                 )
                                 .build())
                 ));

--- a/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
@@ -67,6 +67,7 @@ public class FriendControllerTests extends AbstractControllerTests {
                                         fieldWithPath("code").description("친구 코드")
                                 )
                                 .responseFields(
+                                        fieldWithPath("friendId").description("추가된 친구의 아이디"),
                                         fieldWithPath("friendNickname").description("추가된 친구의 닉네임"),
                                         fieldWithPath("friendProfileUrl").description("추가된 친구의 프로필 이미지 URL")
                                 )
@@ -110,6 +111,7 @@ public class FriendControllerTests extends AbstractControllerTests {
                                 .tag("Friend")
                                 .summary("내 친구 목록을 조회하는 API")
                                 .responseFields(
+                                        fieldWithPath("friendList[0].id").description("친구의 아이디"),
                                         fieldWithPath("friendList[0].nickname").description("친구의 닉네임"),
                                         fieldWithPath("friendList[0].profileUrl").description("친구의 프로필 이미지 URL")
                                 )
@@ -121,11 +123,13 @@ public class FriendControllerTests extends AbstractControllerTests {
     void getWalkStatusList_correctId_success() throws Exception {
         // given
         FriendWalkStatus walkStatus = FriendWalkStatus.builder()
+                .id(1L)
                 .nickname("뽀삐")
                 .profileUrl("https://profile-image.jpg")
                 .done(true)
                 .build();
         FriendWalkStatus walkStatus2 = FriendWalkStatus.builder()
+                .id(2L)
                 .nickname("초코")
                 .profileUrl("https://profile-image.jpg")
                 .done(false)
@@ -148,6 +152,7 @@ public class FriendControllerTests extends AbstractControllerTests {
                                 .tag("Friend")
                                 .summary("내 친구들의 오늘 산책 완료 여부를 조회 API")
                                 .responseFields(
+                                        fieldWithPath("friendWalkStatusList[0].id").description("친구의 아이디"),
                                         fieldWithPath("friendWalkStatusList[0].nickname").description("친구의 닉네임"),
                                         fieldWithPath("friendWalkStatusList[0].profileUrl").description("친구의 프로필 이미지 URL"),
                                         fieldWithPath("friendWalkStatusList[0].done").description("친구의 오늘 산책 완료 여부")

--- a/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/user/presentation/FriendControllerTests.java
@@ -5,11 +5,10 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.nexters.gaetteok.common.presentation.AbstractControllerTests;
 import com.nexters.gaetteok.domain.Friend;
 import com.nexters.gaetteok.domain.User;
-import com.nexters.gaetteok.user.application.FriendApplication;
 import com.nexters.gaetteok.user.presentation.request.CreateFriendRequest;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
@@ -18,8 +17,6 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -52,7 +49,7 @@ public class FriendControllerTests extends AbstractControllerTests {
         CreateFriendRequest request = new CreateFriendRequest(friendUser.getCode());
 
         // when
-        ResultActions resultActions = mockMvc.perform(post("/api/friends")
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.post("/api/friends")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
 
@@ -99,7 +96,7 @@ public class FriendControllerTests extends AbstractControllerTests {
         given(friendApplication.getMyFriendList(anyLong())).willReturn(List.of(friend));
 
         // when
-        ResultActions resultActions = mockMvc.perform(get("/api/friends")
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/friends")
                 .contentType(MediaType.APPLICATION_JSON));
 
         resultActions

--- a/api/src/test/java/com/nexters/gaetteok/user/presentation/UserControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/user/presentation/UserControllerTests.java
@@ -34,10 +34,8 @@ public class UserControllerTests extends AbstractControllerTests {
         given(userApplication.getUser(anyLong())).willReturn(user);
 
         // when
-        ResultActions resultActions = mockMvc.perform(
-            RestDocumentationRequestBuilders.get("/api/users", id)
-                .contentType("application/json")
-                .content(objectMapper.writeValueAsString(user)));
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/users", id)
+                        .contentType("application/json"));
 
         // then
         resultActions.andExpect(MockMvcResultMatchers.status().isOk())

--- a/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
@@ -1,0 +1,144 @@
+package com.nexters.gaetteok.walklog.presentation;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.nexters.gaetteok.common.presentation.AbstractControllerTests;
+import com.nexters.gaetteok.domain.WalkLog;
+import com.nexters.gaetteok.domain.WalkTime;
+import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class WalkLogControllerTests extends AbstractControllerTests {
+
+    @Test
+    void create_correctData_success() throws Exception {
+        // given
+        WalkLog walkLog = WalkLog.builder()
+                .id(1L)
+                .title("산책굳")
+                .content("오늘 산책 짱 좋았당")
+                .photoUrl("https://photo-url/walklog/20240810.jpg")
+                .walkTime(WalkTime.BETWEEN_20_AND_40_MINUTES)
+                .writerNickname("뽀삐")
+                .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
+                .createdAt(LocalDateTime.now())
+                .build();
+        CreateWalkLogRequest request = new CreateWalkLogRequest("산책굳", "오늘 산책 짱 좋았당", WalkTime.BETWEEN_20_AND_40_MINUTES);
+        given(walkLogApplication.create(anyLong(), any(), any())).willReturn(walkLog);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.multipart("/api/walk-logs")
+                .file(new MockMultipartFile("request", "", "application/json", objectMapper.writeValueAsBytes(request)))
+                .file(new MockMultipartFile("photo", "photo".getBytes()))
+                .contentType(MediaType.MULTIPART_FORM_DATA));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document(
+                        "산책 기록 등록",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParts(
+                                partWithName("request").description("요청 데이터"),
+                                partWithName("photo").description("산책 기록 사진")
+                        ),
+                        requestPartFields(
+                                "request",
+                                fieldWithPath("title").description("산책 기록 제목"),
+                                fieldWithPath("content").description("산책 기록 내용"),
+                                fieldWithPath("walkTime").description("산책한 시간")
+                        ),
+                        responseFields(
+                                fieldWithPath("id").description("산책 기록 ID"),
+                                fieldWithPath("photoUrl").description("산책 기록 사진 URL"),
+                                fieldWithPath("title").description("산책 기록 제목"),
+                                fieldWithPath("content").description("산책 기록 내용"),
+                                fieldWithPath("walkTime").description("산책한 시간"),
+                                fieldWithPath("writerNickname").description("작성자 닉네임"),
+                                fieldWithPath("writerProfileUrl").description("작성자 프로필 URL"),
+                                fieldWithPath("createdAt").description("등록 시간")
+                        ),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("WalkLog")
+                                .summary("산책 기록을 등록하는 API")
+                                .build())
+                ));
+
+    }
+
+    @Test
+    void getMyList_correctId_success() throws Exception {
+        // given
+        WalkLog walkLog = WalkLog.builder()
+                .id(1L)
+                .title("산책굳")
+                .content("오늘 산책 짱 좋았당")
+                .photoUrl("https://photo-url/walklog/20240810.jpg")
+                .walkTime(WalkTime.BETWEEN_20_AND_40_MINUTES)
+                .writerNickname("뽀삐")
+                .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
+                .createdAt(LocalDateTime.now())
+                .build();
+        WalkLog walkLog2 = WalkLog.builder()
+                .id(2L)
+                .title("산책 또 굳")
+                .content("오늘 산책도 짱 좋았당")
+                .photoUrl("https://photo-url/walklog/20240810.jpg")
+                .walkTime(WalkTime.WITHIN_20_MINUTES)
+                .writerNickname("뽀삐")
+                .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
+                .createdAt(LocalDateTime.now())
+                .build();
+        given(walkLogApplication.getMyList(anyLong(), anyLong(), anyInt())).willReturn(List.of(walkLog, walkLog2));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/walk-logs/me")
+                .param("cursorId", "15")
+                .param("pageSize", "10")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document(
+                        "내 산책 기록 목록 조회",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("WalkLog")
+                                .summary("내 산책 기록 목록을 조회하는 API")
+                                .queryParameters(
+                                        parameterWithName("cursorId").description("커서. 해당 아이디값보다 아이디가 작은 산책 기록을 조회. 없으면 가장 최근 것부터 조회").optional(),
+                                        parameterWithName("pageSize").description("한 번에 조회할 산책 기록 수. 기본값은 10개").optional()
+                                )
+                                .responseFields(
+                                        fieldWithPath("walkLogList[0].id").description("산책 기록 ID"),
+                                        fieldWithPath("walkLogList[0].photoUrl").description("산책 기록 사진 URL"),
+                                        fieldWithPath("walkLogList[0].title").description("산책 기록 제목"),
+                                        fieldWithPath("walkLogList[0].content").description("산책 기록 내용"),
+                                        fieldWithPath("walkLogList[0].walkTime").description("산책한 시간"),
+                                        fieldWithPath("walkLogList[0].writerNickname").description("작성자 닉네임"),
+                                        fieldWithPath("walkLogList[0].writerProfileUrl").description("작성자 프로필 URL"),
+                                        fieldWithPath("walkLogList[0].createdAt").description("등록 시간")
+                                )
+                                .build())
+                ));
+    }
+
+}

--- a/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
@@ -128,14 +128,14 @@ public class WalkLogControllerTests extends AbstractControllerTests {
                                         parameterWithName("pageSize").description("한 번에 조회할 산책 기록 수. 기본값은 10개").optional()
                                 )
                                 .responseFields(
-                                        fieldWithPath("walkLogList[0].id").description("산책 기록 ID"),
-                                        fieldWithPath("walkLogList[0].photoUrl").description("산책 기록 사진 URL"),
-                                        fieldWithPath("walkLogList[0].title").description("산책 기록 제목"),
-                                        fieldWithPath("walkLogList[0].content").description("산책 기록 내용"),
-                                        fieldWithPath("walkLogList[0].walkTime").description("산책한 시간"),
-                                        fieldWithPath("walkLogList[0].writerNickname").description("작성자 닉네임"),
-                                        fieldWithPath("walkLogList[0].writerProfileUrl").description("작성자 프로필 URL"),
-                                        fieldWithPath("walkLogList[0].createdAt").description("등록 시간")
+                                        fieldWithPath("items[0].id").description("산책 기록 ID"),
+                                        fieldWithPath("items[0].photoUrl").description("산책 기록 사진 URL"),
+                                        fieldWithPath("items[0].title").description("산책 기록 제목"),
+                                        fieldWithPath("items[0].content").description("산책 기록 내용"),
+                                        fieldWithPath("items[0].walkTime").description("산책한 시간"),
+                                        fieldWithPath("items[0].writerNickname").description("작성자 닉네임"),
+                                        fieldWithPath("items[0].writerProfileUrl").description("작성자 프로필 URL"),
+                                        fieldWithPath("items[0].createdAt").description("등록 시간")
                                 )
                                 .build())
                 ));
@@ -189,14 +189,14 @@ public class WalkLogControllerTests extends AbstractControllerTests {
                                         parameterWithName("pageSize").description("한 번에 조회할 산책 기록 수. 기본값은 10개").optional()
                                 )
                                 .responseFields(
-                                        fieldWithPath("walkLogList[0].id").description("산책 기록 ID"),
-                                        fieldWithPath("walkLogList[0].photoUrl").description("산책 기록 사진 URL"),
-                                        fieldWithPath("walkLogList[0].title").description("산책 기록 제목"),
-                                        fieldWithPath("walkLogList[0].content").description("산책 기록 내용"),
-                                        fieldWithPath("walkLogList[0].walkTime").description("산책한 시간"),
-                                        fieldWithPath("walkLogList[0].writerNickname").description("작성자 닉네임"),
-                                        fieldWithPath("walkLogList[0].writerProfileUrl").description("작성자 프로필 URL"),
-                                        fieldWithPath("walkLogList[0].createdAt").description("등록 시간")
+                                        fieldWithPath("items[0].id").description("산책 기록 ID"),
+                                        fieldWithPath("items[0].photoUrl").description("산책 기록 사진 URL"),
+                                        fieldWithPath("items[0].title").description("산책 기록 제목"),
+                                        fieldWithPath("items[0].content").description("산책 기록 내용"),
+                                        fieldWithPath("items[0].walkTime").description("산책한 시간"),
+                                        fieldWithPath("items[0].writerNickname").description("작성자 닉네임"),
+                                        fieldWithPath("items[0].writerProfileUrl").description("작성자 프로필 URL"),
+                                        fieldWithPath("items[0].createdAt").description("등록 시간")
                                 )
                                 .build())
                 ));

--- a/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
@@ -141,4 +141,63 @@ public class WalkLogControllerTests extends AbstractControllerTests {
                 ));
     }
 
+    @Test
+    void getList_correctId_success() throws Exception {
+        // given
+        WalkLog walkLog = WalkLog.builder()
+                .id(1L)
+                .title("산책굳")
+                .content("오늘 산책 짱 좋았당")
+                .photoUrl("https://photo-url/walklog/20240810.jpg")
+                .walkTime(WalkTime.BETWEEN_20_AND_40_MINUTES)
+                .writerNickname("뽀삐")
+                .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
+                .createdAt(LocalDateTime.now())
+                .build();
+        WalkLog walkLog2 = WalkLog.builder()
+                .id(2L)
+                .title("나도 산책 굳")
+                .content("오늘 강아지 짱 많음")
+                .photoUrl("https://photo-url/walklog/20240810.jpg")
+                .walkTime(WalkTime.WITHIN_20_MINUTES)
+                .writerNickname("초코")
+                .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
+                .createdAt(LocalDateTime.now())
+                .build();
+        given(walkLogApplication.getList(anyLong(), anyLong(), anyInt())).willReturn(List.of(walkLog, walkLog2));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/walk-logs")
+                .param("cursorId", "15")
+                .param("pageSize", "10")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document(
+                        "오늘의 산책 기록 목록 조회",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("WalkLog")
+                                .summary("오늘의 산책 기록 목록을 조회하는 API")
+                                .queryParameters(
+                                        parameterWithName("cursorId").description("커서. 해당 아이디값보다 아이디가 작은 산책 기록을 조회. 없으면 가장 최근 것부터 조회").optional(),
+                                        parameterWithName("pageSize").description("한 번에 조회할 산책 기록 수. 기본값은 10개").optional()
+                                )
+                                .responseFields(
+                                        fieldWithPath("walkLogList[0].id").description("산책 기록 ID"),
+                                        fieldWithPath("walkLogList[0].photoUrl").description("산책 기록 사진 URL"),
+                                        fieldWithPath("walkLogList[0].title").description("산책 기록 제목"),
+                                        fieldWithPath("walkLogList[0].content").description("산책 기록 내용"),
+                                        fieldWithPath("walkLogList[0].walkTime").description("산책한 시간"),
+                                        fieldWithPath("walkLogList[0].writerNickname").description("작성자 닉네임"),
+                                        fieldWithPath("walkLogList[0].writerProfileUrl").description("작성자 프로필 URL"),
+                                        fieldWithPath("walkLogList[0].createdAt").description("등록 시간")
+                                )
+                                .build())
+                ));
+    }
+
 }

--- a/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
@@ -105,7 +105,7 @@ public class WalkLogControllerTests extends AbstractControllerTests {
                 .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
                 .createdAt(LocalDateTime.now())
                 .build();
-        given(walkLogApplication.getMyList(anyLong(), anyLong(), anyInt())).willReturn(List.of(walkLog, walkLog2));
+        given(walkLogApplication.getListById(anyLong(), anyLong(), anyInt())).willReturn(List.of(walkLog, walkLog2));
 
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/walk-logs/me")
@@ -142,32 +142,33 @@ public class WalkLogControllerTests extends AbstractControllerTests {
     }
 
     @Test
-    void getList_correctId_success() throws Exception {
+    void getListById_correctId_success() throws Exception {
         // given
         WalkLog walkLog = WalkLog.builder()
-                .id(1L)
+                .id(2L)
                 .title("산책굳")
                 .content("오늘 산책 짱 좋았당")
                 .photoUrl("https://photo-url/walklog/20240810.jpg")
                 .walkTime(WalkTime.BETWEEN_20_AND_40_MINUTES)
-                .writerNickname("뽀삐")
+                .writerNickname("초코")
                 .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
                 .createdAt(LocalDateTime.now())
                 .build();
         WalkLog walkLog2 = WalkLog.builder()
                 .id(2L)
-                .title("나도 산책 굳")
-                .content("오늘 강아지 짱 많음")
+                .title("산책 또 굳")
+                .content("오늘 산책도 짱 좋았당")
                 .photoUrl("https://photo-url/walklog/20240810.jpg")
                 .walkTime(WalkTime.WITHIN_20_MINUTES)
                 .writerNickname("초코")
                 .writerProfileUrl("https://photo-url/walklog/20240810.jpg")
                 .createdAt(LocalDateTime.now())
                 .build();
-        given(walkLogApplication.getList(anyLong(), anyLong(), anyInt())).willReturn(List.of(walkLog, walkLog2));
+        given(walkLogApplication.getListById(anyLong(), anyLong(), anyInt())).willReturn(List.of(walkLog, walkLog2));
 
         // when
         ResultActions resultActions = mockMvc.perform(RestDocumentationRequestBuilders.get("/api/walk-logs")
+                .param("userId", "2")
                 .param("cursorId", "15")
                 .param("pageSize", "10")
                 .contentType(MediaType.APPLICATION_JSON));
@@ -176,13 +177,14 @@ public class WalkLogControllerTests extends AbstractControllerTests {
         resultActions
                 .andExpect(status().isOk())
                 .andDo(MockMvcRestDocumentationWrapper.document(
-                        "오늘의 산책 기록 목록 조회",
+                        "산책 기록 목록 조회",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(ResourceSnippetParameters.builder()
                                 .tag("WalkLog")
-                                .summary("오늘의 산책 기록 목록을 조회하는 API")
+                                .summary("산책 기록 목록을 조회하는 API")
                                 .queryParameters(
+                                        parameterWithName("userId").description("사용자 아이디. 생략하면 나 포함 모든 친구의 산책 기록 조회").optional(),
                                         parameterWithName("cursorId").description("커서. 해당 아이디값보다 아이디가 작은 산책 기록을 조회. 없으면 가장 최근 것부터 조회").optional(),
                                         parameterWithName("pageSize").description("한 번에 조회할 산책 기록 수. 기본값은 10개").optional()
                                 )

--- a/domain/user/src/main/java/com/nexters/gaetteok/domain/Friend.java
+++ b/domain/user/src/main/java/com/nexters/gaetteok/domain/Friend.java
@@ -2,10 +2,12 @@ package com.nexters.gaetteok.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Getter
+@ToString
 public class Friend {
 
     private long id;

--- a/domain/user/src/main/java/com/nexters/gaetteok/domain/FriendWalkStatus.java
+++ b/domain/user/src/main/java/com/nexters/gaetteok/domain/FriendWalkStatus.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @Getter
 public class FriendWalkStatus {
 
+    private long id;
+
     private String nickname;
 
     private String profileUrl;
@@ -13,7 +15,8 @@ public class FriendWalkStatus {
     private boolean done;
 
     @Builder
-    public FriendWalkStatus(String nickname, String profileUrl, boolean done) {
+    public FriendWalkStatus(long id, String nickname, String profileUrl, boolean done) {
+        this.id = id;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
         this.done = done;

--- a/domain/user/src/main/java/com/nexters/gaetteok/domain/FriendWalkStatus.java
+++ b/domain/user/src/main/java/com/nexters/gaetteok/domain/FriendWalkStatus.java
@@ -1,0 +1,22 @@
+package com.nexters.gaetteok.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FriendWalkStatus {
+
+    private String nickname;
+
+    private String profileUrl;
+
+    private boolean done;
+
+    @Builder
+    public FriendWalkStatus(String nickname, String profileUrl, boolean done) {
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+        this.done = done;
+    }
+
+}

--- a/domain/user/src/main/java/com/nexters/gaetteok/domain/User.java
+++ b/domain/user/src/main/java/com/nexters/gaetteok/domain/User.java
@@ -1,10 +1,13 @@
 package com.nexters.gaetteok.domain;
 
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
+@ToString
 public class User {
 
     private long id;

--- a/domain/walklog/build.gradle
+++ b/domain/walklog/build.gradle
@@ -1,0 +1,7 @@
+jar {
+    enabled = true
+}
+
+bootJar {
+    enabled = false
+}

--- a/domain/walklog/src/main/java/com/nexters/gaetteok/domain/WalkLog.java
+++ b/domain/walklog/src/main/java/com/nexters/gaetteok/domain/WalkLog.java
@@ -1,0 +1,41 @@
+package com.nexters.gaetteok.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class WalkLog {
+
+    private long id;
+
+    private String photoUrl;
+
+    private String title;
+
+    private String content;
+
+    private WalkTime walkTime;
+
+    private String writerNickname;
+
+    private String writerProfileUrl;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public WalkLog(long id, String photoUrl, String title, String content, WalkTime walkTime, String writerNickname, String writerProfileUrl, LocalDateTime createdAt) {
+        this.id = id;
+        this.photoUrl = photoUrl;
+        this.title = title;
+        this.content = content;
+        this.walkTime = walkTime;
+        this.writerNickname = writerNickname;
+        this.writerProfileUrl = writerProfileUrl;
+        this.createdAt = createdAt;
+    }
+
+}

--- a/domain/walklog/src/main/java/com/nexters/gaetteok/domain/WalkTime.java
+++ b/domain/walklog/src/main/java/com/nexters/gaetteok/domain/WalkTime.java
@@ -1,0 +1,33 @@
+package com.nexters.gaetteok.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum WalkTime {
+
+    WITHIN_20_MINUTES("20분 내외"),  // 20분 내외
+    BETWEEN_20_AND_40_MINUTES("20분~40분"),  // 20분~40분
+    BETWEEN_40_MINUTES_AND_1_HOUR("40분~1시간"),  // 40분~1시간
+    ;
+
+    private final String description;
+    private static final Map<String, WalkTime> descriptionMap = Arrays.stream(values())
+            .collect(Collectors.toMap(WalkTime::getDescription, e -> e));
+
+    WalkTime(String description) {
+        this.description = description;
+    }
+
+    @JsonValue
+    public String getDescription() {
+        return description;
+    }
+
+    public static WalkTime findByDescription(String description) {
+        return descriptionMap.get(description);
+    }
+
+}

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    implementation project(':domain:user')
     implementation project(':domain:walklog')
 }
 

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -1,9 +1,20 @@
 dependencies {
+    // Object Storage
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.765')
     implementation 'com.amazonaws:aws-java-sdk-s3'
+
+    // DB & JPA
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    implementation project(':domain:walklog')
 }
 
 jar {

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/config/JpaConfig.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/config/JpaConfig.java
@@ -1,10 +1,22 @@
 package com.nexters.gaetteok.persistence.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/config/WalkTimeConverter.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/config/WalkTimeConverter.java
@@ -1,0 +1,20 @@
+package com.nexters.gaetteok.persistence.config;
+
+import com.nexters.gaetteok.domain.WalkTime;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class WalkTimeConverter implements AttributeConverter<WalkTime, String> {
+
+    @Override
+    public String convertToDatabaseColumn(WalkTime attribute) {
+        return attribute.getDescription();
+    }
+
+    @Override
+    public WalkTime convertToEntityAttribute(String dbData) {
+        return WalkTime.findByDescription(dbData);
+    }
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/FriendEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/FriendEntity.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "friend", indexes = {@Index(name = "my_user_id_idx", columnList = "my_user_id")})
+@Table(name = "friend", indexes = {@Index(name = "idx_friend_my_user_id", columnList = "my_user_id")})
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,7 +28,7 @@ public class FriendEntity {
     private long friendUserId;
 
     @CreatedDate
-    @Column(insertable = false, updatable = false)
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @Builder

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/UserEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/UserEntity.java
@@ -1,7 +1,10 @@
 package com.nexters.gaetteok.persistence.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -10,6 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "user")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class UserEntity {
 
@@ -25,6 +29,16 @@ public class UserEntity {
     private String code;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    @Builder
+    public UserEntity(long id, String nickname, String profileUrl, String code, LocalDateTime createdAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+        this.code = code;
+        this.createdAt = createdAt;
+    }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/WalkLogEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/WalkLogEntity.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +15,8 @@ import java.time.LocalDateTime;
         @Index(name = "idx_walk_log_user_id", columnList = "user_id")
 })
 @Getter
-@EntityListeners(AuditingEntityListener.class)
+// FIXME : 테스트 데이터 주입 때문에 임시로 생성일자 직접 주입 방식으로 돌림 (테스트 데이터 주입 코드 제거할 때 주석 해제)
+//@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WalkLogEntity {
 

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/WalkLogEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/WalkLogEntity.java
@@ -1,0 +1,55 @@
+package com.nexters.gaetteok.persistence.entity;
+
+import com.nexters.gaetteok.domain.WalkTime;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "walk_log", indexes = {
+        @Index(name = "idx_walk_log_user_id", columnList = "user_id")
+})
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WalkLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String photoUrl;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "walk_time")
+    private WalkTime walkTime;
+
+    @Column(name = "user_id")
+    private long userId;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public WalkLogEntity(long id, String photoUrl, String title, String content, WalkTime walkTime, long userId, LocalDateTime createdAt) {
+        this.id = id;
+        this.photoUrl = photoUrl;
+        this.title = title;
+        this.content = content;
+        this.walkTime = walkTime;
+        this.userId = userId;
+        this.createdAt = createdAt;
+    }
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepository.java
@@ -1,0 +1,12 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.domain.FriendWalkStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CustomFriendRepository {
+
+    List<FriendWalkStatus> getFriendWalkStatus(long userId, LocalDate date);
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.domain.FriendWalkStatus;
+import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.nexters.gaetteok.persistence.entity.QFriendEntity.friendEntity;
+import static com.nexters.gaetteok.persistence.entity.QUserEntity.userEntity;
+import static com.nexters.gaetteok.persistence.entity.QWalkLogEntity.walkLogEntity;
+import static com.querydsl.core.types.dsl.Expressions.dateTimeOperation;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomFriendRepositoryImpl implements CustomFriendRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<FriendWalkStatus> getFriendWalkStatus(long userId, LocalDate date) {
+        List<Long> friendIdList = jpaQueryFactory
+                .select(friendEntity.friendUserId)
+                .from(friendEntity)
+                .where(friendEntity.myUserId.eq(userId))
+                .fetch();
+
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        FriendWalkStatus.class,
+                        userEntity.nickname,
+                        userEntity.profileUrl,
+                        walkLogEntity.count().gt(0).as("done")
+                ))
+                .from(userEntity)
+                .leftJoin(walkLogEntity).on(
+                        userEntity.id.eq(walkLogEntity.userId),
+                        dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date)
+                )
+                .where(userEntity.id.in(friendIdList))
+                .groupBy(userEntity.nickname, userEntity.profileUrl)
+                .orderBy(walkLogEntity.createdAt.max().desc())
+                .fetch();
+    }
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepositoryImpl.java
@@ -32,6 +32,7 @@ public class CustomFriendRepositoryImpl implements CustomFriendRepository {
         return jpaQueryFactory
                 .select(Projections.constructor(
                         FriendWalkStatus.class,
+                        userEntity.id,
                         userEntity.nickname,
                         userEntity.profileUrl,
                         walkLogEntity.count().gt(0).as("done")
@@ -42,7 +43,7 @@ public class CustomFriendRepositoryImpl implements CustomFriendRepository {
                         dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date)
                 )
                 .where(userEntity.id.in(friendIdList))
-                .groupBy(userEntity.nickname, userEntity.profileUrl)
+                .groupBy(userEntity.id, userEntity.nickname, userEntity.profileUrl)
                 .orderBy(walkLogEntity.createdAt.max().desc())
                 .fetch();
     }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
@@ -3,13 +3,12 @@ package com.nexters.gaetteok.persistence.repository;
 import com.nexters.gaetteok.domain.WalkLog;
 import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface CustomWalkLogRepository {
 
     List<WalkLogEntity> getMyList(long userId, long cursorId, int pageSize);
 
-    List<WalkLog> getList(long userId, long cursorId, int pageSize, LocalDate date);
+    List<WalkLog> getList(long userId, long cursorId, int pageSize);
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
@@ -1,11 +1,15 @@
 package com.nexters.gaetteok.persistence.repository;
 
+import com.nexters.gaetteok.domain.WalkLog;
 import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface CustomWalkLogRepository {
 
     List<WalkLogEntity> getMyList(long userId, long cursorId, int pageSize);
+
+    List<WalkLog> getList(long userId, long cursorId, int pageSize, LocalDate date);
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
@@ -1,0 +1,11 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+
+import java.util.List;
+
+public interface CustomWalkLogRepository {
+
+    List<WalkLogEntity> getMyList(long userId, long cursorId, int pageSize);
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.nexters.gaetteok.persistence.entity.QWalkLogEntity.walkLogEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<WalkLogEntity> getMyList(long userId, long cursorId, int pageSize) {
+        return jpaQueryFactory.selectFrom(walkLogEntity)
+                .where(walkLogEntity.userId.eq(userId), cursorId > 0 ? walkLogEntity.id.lt(cursorId) : null)
+                .orderBy(walkLogEntity.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -2,19 +2,16 @@ package com.nexters.gaetteok.persistence.repository;
 
 import com.nexters.gaetteok.domain.WalkLog;
 import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
-import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static com.nexters.gaetteok.persistence.entity.QFriendEntity.friendEntity;
 import static com.nexters.gaetteok.persistence.entity.QUserEntity.userEntity;
 import static com.nexters.gaetteok.persistence.entity.QWalkLogEntity.walkLogEntity;
-import static com.querydsl.core.types.dsl.Expressions.dateTimeOperation;
 
 @Repository
 @RequiredArgsConstructor
@@ -32,7 +29,7 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
     }
 
     @Override
-    public List<WalkLog> getList(long userId, long cursorId, int pageSize, LocalDate date) {
+    public List<WalkLog> getList(long userId, long cursorId, int pageSize) {
         List<Long> friendIdList = jpaQueryFactory
                 .select(friendEntity.friendUserId)
                 .from(friendEntity)
@@ -57,7 +54,6 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
                 .on(userEntity.id.eq(walkLogEntity.userId))
                 .where(
                         cursorId > 0 ? walkLogEntity.id.lt(cursorId) : null,
-                        dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date),
                         userEntity.id.in(friendIdList)
                 )
                 .limit(pageSize)

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -1,13 +1,20 @@
 package com.nexters.gaetteok.persistence.repository;
 
+import com.nexters.gaetteok.domain.WalkLog;
 import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import static com.nexters.gaetteok.persistence.entity.QFriendEntity.friendEntity;
+import static com.nexters.gaetteok.persistence.entity.QUserEntity.userEntity;
 import static com.nexters.gaetteok.persistence.entity.QWalkLogEntity.walkLogEntity;
+import static com.querydsl.core.types.dsl.Expressions.dateTimeOperation;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,6 +28,40 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
                 .where(walkLogEntity.userId.eq(userId), cursorId > 0 ? walkLogEntity.id.lt(cursorId) : null)
                 .orderBy(walkLogEntity.id.desc())
                 .limit(pageSize)
+                .fetch();
+    }
+
+    @Override
+    public List<WalkLog> getList(long userId, long cursorId, int pageSize, LocalDate date) {
+        List<Long> friendIdList = jpaQueryFactory
+                .select(friendEntity.friendUserId)
+                .from(friendEntity)
+                .where(friendEntity.myUserId.eq(userId))
+                .fetch();
+        // 피드에는 나도 포함
+        friendIdList.add(userId);
+
+        return jpaQueryFactory.select(Projections.constructor(
+                        WalkLog.class,
+                        walkLogEntity.id,
+                        walkLogEntity.photoUrl,
+                        walkLogEntity.title,
+                        walkLogEntity.content,
+                        walkLogEntity.walkTime,
+                        userEntity.nickname,
+                        userEntity.profileUrl,
+                        walkLogEntity.createdAt
+                ))
+                .from(walkLogEntity)
+                .join(userEntity)
+                .on(userEntity.id.eq(walkLogEntity.userId))
+                .where(
+                        cursorId > 0 ? walkLogEntity.id.lt(cursorId) : null,
+                        dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date),
+                        userEntity.id.in(friendIdList)
+                )
+                .limit(pageSize)
+                .orderBy(walkLogEntity.id.desc())
                 .fetch();
     }
 

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/FriendRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/FriendRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface FriendRepository extends JpaRepository<FriendEntity, Long> {
+public interface FriendRepository extends JpaRepository<FriendEntity, Long>, CustomFriendRepository {
 
     List<FriendEntity> findByMyUserId(long id);
 

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/UserRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/UserRepository.java
@@ -9,4 +9,9 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByCode(String code);
 
+    default UserEntity getById(long userId) {
+        return findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다. userId: " + userId));
+    }
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/WalkLogRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/WalkLogRepository.java
@@ -1,0 +1,8 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalkLogRepository extends JpaRepository<WalkLogEntity, Long>, CustomWalkLogRepository {
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,4 @@ include 'api'
 include 'infra'
 include 'domain'
 include 'domain:user'
-
+include 'domain:walklog'


### PR DESCRIPTION
- 친구 API, 친구의 오늘 산책 여부 API, 산책 기록 생성/조회 API 추가
- 일단 테스트 데이터 주입은 서버 최초 구동 시 create-drop으로 기존 데이터 싹 날리고 엔티티 매니저로 주입
  - 더 우아한 해결법이 있다면 추천 받습니다...
- 아마 문서화 방식을 restdocs으로 openapi 문서 뽑고 이걸 swaggerUI로 보여주는 현재 방식에서, 그냥 springdocs + swagger 방식으로 변경할듯?
  - 사유: 멀티파트 포함한 API의 요청부가 제대로 문서화가 안 되는데, 이 문제가 아직까지도 해결되지 않음... (공식 리포지토리의 https://github.com/ePages-de/restdocs-api-spec/issues/105 참조)