### PR TITLE
Update feed APIs, weather response

### DIFF
--- a/api/src/main/java/com/nexters/gaetteok/common/service/TestDataInjector.java
+++ b/api/src/main/java/com/nexters/gaetteok/common/service/TestDataInjector.java
@@ -1,16 +1,11 @@
 package com.nexters.gaetteok.common.service;
 
-import com.nexters.gaetteok.domain.AuthProvider;
-import com.nexters.gaetteok.domain.Comment;
-import com.nexters.gaetteok.domain.WalkLog;
-import com.nexters.gaetteok.domain.WalkTime;
-import com.nexters.gaetteok.persistence.entity.CommentEntity;
-import com.nexters.gaetteok.persistence.entity.FriendEntity;
-import com.nexters.gaetteok.persistence.entity.UserEntity;
-import com.nexters.gaetteok.persistence.entity.WalkLogEntity;
+import com.nexters.gaetteok.domain.*;
+import com.nexters.gaetteok.persistence.entity.*;
 import com.nexters.gaetteok.user.mapper.FriendMapper;
 import com.nexters.gaetteok.user.mapper.UserMapper;
 import com.nexters.gaetteok.walklog.mapper.CommentMapper;
+import com.nexters.gaetteok.walklog.mapper.ReactionMapper;
 import com.nexters.gaetteok.walklog.mapper.WalkLogMapper;
 import com.nexters.gaetteok.weather.enums.City;
 import jakarta.persistence.EntityManager;
@@ -120,6 +115,7 @@ public class TestDataInjector {
         };
         List<WalkLog> walkLogList = new ArrayList<>();
         List<Comment> comments = new ArrayList<>();
+        List<Reaction> reactions = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             WalkLogEntity walkLogEntity = entityManager.merge(WalkLogEntity.builder()
                 .userId(poppy.getId())
@@ -132,15 +128,35 @@ public class TestDataInjector {
             walkLogList.add(WalkLogMapper.toDomain(walkLogEntity, poppy));
 
             CommentEntity commentEntity = entityManager.merge(CommentEntity.builder()
-                .writerId(poppy.getId())
+                .userId(poppy.getId())
                 .content("오늘 산책 지리더라")
                 .walkLogId(walkLogEntity.getId())
                 .createdAt(LocalDateTime.now().minusDays(20 - i))
                 .build());
+            CommentEntity friendCommentEntity = entityManager.merge(CommentEntity.builder()
+                .userId(choco.getId())
+                .content("개기여워~")
+                .walkLogId(walkLogEntity.getId())
+                .createdAt(LocalDateTime.now().minusDays(20 - i))
+                .build());
             comments.add(CommentMapper.toDomain(commentEntity, poppy));
+            comments.add(CommentMapper.toDomain(friendCommentEntity, choco));
+            ReactionEntity reactionEntity = entityManager.merge(ReactionEntity.builder()
+                .userId(poppy.getId())
+                .walkLogId(walkLogEntity.getId())
+                .reactionType(ReactionType.LIKE)
+                .build());
+            ReactionEntity friendReactionEntity = entityManager.merge(ReactionEntity.builder()
+                .userId(happy.getId())
+                .walkLogId(walkLogEntity.getId())
+                .reactionType(ReactionType.IMPRESSIVE)
+                .build());
+            reactions.add(ReactionMapper.toDomain(reactionEntity, poppy));
+            reactions.add(ReactionMapper.toDomain(friendReactionEntity, happy));
         }
         log.info("뽀삐 산책 기록 저장: {}", walkLogList);
         log.info("뽀삐 산책 기록에 대한 댓글 저장: {}", comments);
+        log.info("뽀삐 산책 기록에 대한 반응 저장: {}", reactions);
 
         WalkLogEntity chocoWalkLog = entityManager.merge(WalkLogEntity.builder()
             .userId(choco.getId())

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/CommentApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/CommentApplication.java
@@ -20,13 +20,13 @@ public class CommentApplication {
     private final CommentRepository commentRepository;
 
     @Transactional
-    public Comment create(long writerId, long walkLogId, CreateCommentRequest request) {
-        UserEntity userEntity = userRepository.findById(writerId)
-            .orElseThrow(() -> new RuntimeException("User with id " + writerId + " not found"));
+    public Comment create(long userId, long walkLogId, CreateCommentRequest request) {
+        UserEntity userEntity = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("User with id " + userId + " not found"));
         CommentEntity commentEntity = CommentEntity.builder()
             .walkLogId(walkLogId)
             .content(request.getContent())
-            .writerId(writerId)
+            .userId(userId)
             .build();
 
         CommentEntity savedEntity = commentRepository.save(commentEntity);
@@ -38,15 +38,15 @@ public class CommentApplication {
     public Comment update(long commentId, UpdateCommentRequest request) {
         CommentEntity commentEntity = commentRepository.findById(commentId)
             .orElseThrow(() -> new RuntimeException("Comment with id " + commentId + " not found"));
-        UserEntity userEntity = userRepository.findById(commentEntity.getWriterId())
+        UserEntity userEntity = userRepository.findById(commentEntity.getUserId())
             .orElseThrow(() -> new RuntimeException(
-                "User with id " + commentEntity.getWriterId() + " not found"));
+                "User with id " + commentEntity.getUserId() + " not found"));
 
         CommentEntity updatedCommentEntity = CommentEntity.builder()
             .id(commentEntity.getId())
             .walkLogId(commentEntity.getWalkLogId())
             .content(request.getContent())
-            .writerId(commentEntity.getWriterId())
+            .userId(commentEntity.getUserId())
             .build();
 
         CommentEntity savedEntity = commentRepository.save(updatedCommentEntity);

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -18,17 +18,20 @@ import com.nexters.gaetteok.walklog.mapper.ReactionMapper;
 import com.nexters.gaetteok.walklog.mapper.WalkLogMapper;
 import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.PatchWalkLogRequest;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -148,9 +151,10 @@ public class WalkLogApplication {
     }
 
     @Transactional(readOnly = true)
-    public WalkLog getOneById(long walkLogId, long userId) {
-        UserEntity userEntity = userRepository.getById(userId);
-        WalkLog walkLog = WalkLogMapper.toDomain(walkLogRepository.getById(walkLogId), userEntity);
+    public WalkLog getOneById(long walkLogId) {
+        WalkLogEntity walkLogEntity = walkLogRepository.getById(walkLogId);
+        UserEntity userEntity = userRepository.getById(walkLogEntity.getUserId());
+        WalkLog walkLog = WalkLogMapper.toDomain(walkLogEntity, userEntity);
 
         List<Comment> comments = commentRepository.findByWalkLogIdInWithUser(walkLogId);
         List<Reaction> reactions = reactionRepository.findByWalkLogIdInWithUser(walkLogId);

--- a/api/src/main/java/com/nexters/gaetteok/walklog/mapper/CommentMapper.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/mapper/CommentMapper.java
@@ -9,6 +9,7 @@ public class CommentMapper {
     public static Comment toDomain(CommentEntity commentEntity, UserEntity userEntity) {
         return Comment.builder()
             .id(commentEntity.getId())
+            .writerId(userEntity.getId())
             .writerNickname(userEntity.getNickname())
             .writerProfileImageUrl(userEntity.getProfileUrl())
             .content(commentEntity.getContent())

--- a/api/src/main/java/com/nexters/gaetteok/walklog/mapper/WalkLogMapper.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/mapper/WalkLogMapper.java
@@ -13,6 +13,7 @@ public class WalkLogMapper {
             .title(entity.getTitle())
             .content(entity.getContent())
             .walkTime(entity.getWalkTime())
+            .writerId(writer.getId())
             .writerNickname(writer.getNickname())
             .writerProfileImageUrl(writer.getProfileUrl())
             .createdAt(entity.getCreatedAt())

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -6,19 +6,24 @@ import com.nexters.gaetteok.walklog.application.WalkLogApplication;
 import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.PatchWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.ReportWalkLogRequest;
-import com.nexters.gaetteok.walklog.presentation.response.*;
+import com.nexters.gaetteok.walklog.presentation.response.CreateWalkLogResponse;
+import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogDetailResponse;
+import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListGroupByMonthResponse;
+import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListResponse;
+import com.nexters.gaetteok.walklog.presentation.response.PatchWalkLogResponse;
+import com.nexters.gaetteok.walklog.presentation.response.ReportWalkLogResponse;
+import com.nexters.gaetteok.walklog.presentation.response.WalkLogCalendarResponse;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @RestController
@@ -135,7 +140,7 @@ public class WalkLogController implements WalkLogSpecification {
     public ResponseEntity<GetWalkLogDetailResponse> getDetail(
         @PathVariable long id,
         UserInfo userInfo) {
-        WalkLog walkLog = walkLogApplication.getOneById(id, userInfo.getUserId());
+        WalkLog walkLog = walkLogApplication.getOneById(id);
 
         return ResponseEntity.ok(
             GetWalkLogDetailResponse.of(walkLog, userInfo));

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -6,32 +6,19 @@ import com.nexters.gaetteok.walklog.application.WalkLogApplication;
 import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.PatchWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.ReportWalkLogRequest;
-import com.nexters.gaetteok.walklog.presentation.response.CreateWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogDetailResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListGroupByMonthResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListResponse;
-import com.nexters.gaetteok.walklog.presentation.response.PatchWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.ReportWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.WalkLogCalendarResponse;
+import com.nexters.gaetteok.walklog.presentation.response.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -151,7 +138,15 @@ public class WalkLogController implements WalkLogSpecification {
         WalkLog walkLog = walkLogApplication.getOneById(id, userInfo.getUserId());
 
         return ResponseEntity.ok(
-            GetWalkLogDetailResponse.of(walkLog));
+            GetWalkLogDetailResponse.of(walkLog, userInfo));
+    }
+
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<Void> delete(
+        @PathVariable long id,
+        UserInfo userInfo) {
+        walkLogApplication.delete(id, userInfo.getUserId());
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
@@ -4,24 +4,19 @@ import com.nexters.gaetteok.jwt.UserInfo;
 import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.PatchWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.ReportWalkLogRequest;
-import com.nexters.gaetteok.walklog.presentation.response.CreateWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogDetailResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListGroupByMonthResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListResponse;
-import com.nexters.gaetteok.walklog.presentation.response.PatchWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.ReportWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.WalkLogCalendarResponse;
+import com.nexters.gaetteok.walklog.presentation.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "WalkLog", description = "산책 기록 API")
 public interface WalkLogSpecification {
@@ -147,5 +142,15 @@ public interface WalkLogSpecification {
         @Parameter(description = "산책 기록 ID") long id,
         @Parameter(hidden = true) UserInfo userInfo
     ) throws IOException;
+
+    @Operation(summary = "산책 기록 삭제", description = "산책 기록을 삭제합니다.")
+    @ApiResponse(
+        responseCode = "204",
+        description = "산책 기록 삭제 성공"
+    )
+    ResponseEntity<Void> delete(
+        @Parameter(description = "산책 기록 ID") long id,
+        @Parameter(hidden = true) UserInfo userInfo
+    );
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetCommentResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetCommentResponse.java
@@ -1,7 +1,6 @@
 package com.nexters.gaetteok.walklog.presentation.response;
 
-import com.nexters.gaetteok.domain.Reaction;
-import com.nexters.gaetteok.domain.ReactionType;
+import com.nexters.gaetteok.domain.Comment;
 import com.nexters.gaetteok.jwt.UserInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -10,10 +9,13 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class GetReactionResponse {
+public class GetCommentResponse {
 
-    @Schema(description = "리액션 ID", example = "1")
+    @Schema(description = "댓글 ID", example = "1")
     private long id;
+
+    @Schema(description = "댓글 내용", example = "댓글 내용")
+    private String content;
 
     @Schema(description = "작성자 ID", example = "1")
     private long writerId;
@@ -23,9 +25,6 @@ public class GetReactionResponse {
 
     @Schema(description = "작성자 프로필 이미지 URL", example = "https://gaetteok.com/profile.jpg")
     private String writerProfileImageUrl;
-
-    @Schema(description = "리액션 타입", example = "LIKE")
-    private ReactionType reactionType;
 
     @Schema(description = "산책 기록 ID", example = "1")
     private long walkLogId;
@@ -37,28 +36,28 @@ public class GetReactionResponse {
     private LocalDateTime createdAt;
 
     @Builder
-    public GetReactionResponse(long id, long writerId, String writerNickname, String writerProfileImageUrl,
-                               ReactionType reactionType, long walkLogId, boolean isMe, LocalDateTime createdAt) {
+    public GetCommentResponse(long id, String content, long writerId, String writerNickname, String writerProfileImageUrl,
+                              long walkLogId, boolean isMe, LocalDateTime createdAt) {
         this.id = id;
+        this.content = content;
         this.writerId = writerId;
         this.writerNickname = writerNickname;
         this.writerProfileImageUrl = writerProfileImageUrl;
-        this.reactionType = reactionType;
         this.walkLogId = walkLogId;
         this.isMe = isMe;
         this.createdAt = createdAt;
     }
 
-    public static GetReactionResponse of(Reaction reaction, UserInfo userInfo) {
-        return GetReactionResponse.builder()
-            .id(reaction.getId())
-            .writerId(reaction.getWriterId())
-            .writerNickname(reaction.getWriterNickname())
-            .writerProfileImageUrl(reaction.getWriterProfileImageUrl())
-            .reactionType(reaction.getReactionType())
-            .walkLogId(reaction.getWalkLogId())
-            .isMe(reaction.getWriterId() == userInfo.getUserId())
-            .createdAt(reaction.getCreatedAt())
+    public static GetCommentResponse of(Comment comment, UserInfo userInfo) {
+        return GetCommentResponse.builder()
+            .id(comment.getId())
+            .content(comment.getContent())
+            .writerId(comment.getWriterId())
+            .writerNickname(comment.getWriterNickname())
+            .writerProfileImageUrl(comment.getWriterProfileImageUrl())
+            .walkLogId(comment.getWalkLogId())
+            .isMe(comment.getWriterId() == userInfo.getUserId())
+            .createdAt(comment.getCreatedAt())
             .build();
     }
 

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogDetailResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/GetWalkLogDetailResponse.java
@@ -1,15 +1,15 @@
 package com.nexters.gaetteok.walklog.presentation.response;
 
-import com.nexters.gaetteok.domain.Comment;
-import com.nexters.gaetteok.domain.Reaction;
 import com.nexters.gaetteok.domain.WalkLog;
 import com.nexters.gaetteok.domain.WalkTime;
+import com.nexters.gaetteok.jwt.UserInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import lombok.Builder;
-import lombok.Getter;
 
 @Getter
 public class GetWalkLogDetailResponse {
@@ -29,51 +29,66 @@ public class GetWalkLogDetailResponse {
     @Schema(description = "산책 시간", examples = {"20분 내외", "20분~40분", "40분~1시간"})
     private WalkTime walkTime;
 
+    @Schema(description = "작성자 ID", example = "1")
+    private long writerId;
+
     @Schema(description = "작성자 닉네임", example = "뽀삐")
     private String writerNickname;
 
     @Schema(description = "작성자 프로필 이미지 URL", example = "https://gaetteok.com/profile.jpg")
     private String writerProfileImageUrl;
 
+    @Schema(description = "작성자가 본인인지 여부", example = "true")
+    private boolean isMe;
+
     @Schema(description = "댓글 리스트")
-    private List<Comment> comments;
+    private List<GetCommentResponse> comments;
 
     @Schema(description = "리액션 리스트")
-    private List<Reaction> reactions;
+    private List<GetReactionResponse> reactions;
 
     @Schema(description = "작성일", example = "2021-07-01T00:00:00")
     private LocalDateTime createdAt;
 
     @Builder
     public GetWalkLogDetailResponse(long id, String photoUrl, String title, String content,
-        WalkTime walkTime, String writerNickname, String writerProfileImageUrl,
-        List<Comment> comments, List<Reaction> reactions,
-        LocalDateTime createdAt) {
+                                    WalkTime walkTime, long writerId, String writerNickname, String writerProfileImageUrl,
+                                    boolean isMe, List<GetCommentResponse> comments, List<GetReactionResponse> reactions,
+                                    LocalDateTime createdAt) {
         this.id = id;
         this.photoUrl = photoUrl;
         this.title = title;
         this.content = content;
         this.walkTime = walkTime;
+        this.writerId = writerId;
         this.writerNickname = writerNickname;
         this.writerProfileImageUrl = writerProfileImageUrl;
+        this.isMe = isMe;
         this.comments = comments;
         this.reactions = reactions;
         this.createdAt = createdAt;
     }
 
-    public static GetWalkLogDetailResponse of(WalkLog walkLog) {
+    public static GetWalkLogDetailResponse of(WalkLog walkLog, UserInfo userInfo) {
+        List<GetCommentResponse> commentResponseList = walkLog.getComments() != null
+            ? walkLog.getComments().stream().map(comment -> GetCommentResponse.of(comment, userInfo)).toList()
+            : Collections.emptyList();
+        List<GetReactionResponse> reactionResponseList = walkLog.getReactions() != null
+            ? walkLog.getReactions().stream().map(reaction -> GetReactionResponse.of(reaction, userInfo)).toList()
+            : Collections.emptyList();
+
         return GetWalkLogDetailResponse.builder()
             .id(walkLog.getId())
             .photoUrl(walkLog.getPhotoUrl())
             .title(walkLog.getTitle())
             .content(walkLog.getContent())
             .walkTime(walkLog.getWalkTime())
+            .writerId(walkLog.getWriterId())
             .writerNickname(walkLog.getWriterNickname())
             .writerProfileImageUrl(walkLog.getWriterProfileImageUrl())
-            .comments(
-                walkLog.getComments() != null ? walkLog.getComments() : Collections.emptyList())
-            .reactions(
-                walkLog.getReactions() != null ? walkLog.getReactions() : Collections.emptyList())
+            .isMe(walkLog.getWriterId() == userInfo.getUserId())
+            .comments(commentResponseList)
+            .reactions(reactionResponseList)
             .createdAt(walkLog.getCreatedAt())
             .build();
     }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/WalkLogCalendarResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/WalkLogCalendarResponse.java
@@ -6,16 +6,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 public class WalkLogCalendarResponse {
 
     @JsonProperty("items")
     @Schema(description = "산책 기록 월별 리스트")
-    private Map<String, WalkLog> walkLogs;
+    private Map<String, GetWalkLogResponse> walkLogs;
 
     public WalkLogCalendarResponse(Map<String, WalkLog> walkLogs) {
-        this.walkLogs = walkLogs;
+        this.walkLogs = walkLogs.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> GetWalkLogResponse.of(entry.getValue())
+                )
+            );
     }
 
     public static WalkLogCalendarResponse of(Map<String, WalkLog> walkLogs) {

--- a/api/src/main/java/com/nexters/gaetteok/weather/presentation/response/MajorWeather.java
+++ b/api/src/main/java/com/nexters/gaetteok/weather/presentation/response/MajorWeather.java
@@ -1,0 +1,30 @@
+package com.nexters.gaetteok.weather.presentation.response;
+
+import com.nexters.gaetteok.weather.enums.Weather;
+import lombok.Getter;
+
+@Getter
+public enum MajorWeather {
+
+    CLEAR("맑은 날씨입니다."),
+    RAIN("우산을 챙겨주세요."),
+    SNOW("눈이 오는 날씨입니다."),
+    CLOUDS("구름이 많은 날씨입니다."),
+    ;
+
+    private final String message;
+
+    MajorWeather(String message) {
+        this.message = message;
+    }
+
+    public static MajorWeather from(Weather weather) {
+        return switch (weather) {
+            case RAIN, THUNDERSTORM, DRIZZLE -> RAIN;
+            case SNOW -> SNOW;
+            case CLOUDS, MIST, HAZE, DUST, FOG, SAND, SQUALL, TORNADO, SMOKE, ASH -> CLOUDS;
+            case CLEAR -> CLEAR;
+        };
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/weather/presentation/response/WeatherResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/weather/presentation/response/WeatherResponse.java
@@ -12,11 +12,15 @@ public class WeatherResponse {
     private Integer temp;
 
     @Schema(description = "날씨")
-    private Weather weather;
+    private MajorWeather weather;
+
+    @Schema(description = "날씨 관련 문구")
+    private String weatherMessage;
 
     @Builder
     public WeatherResponse(Integer temp, Weather weather) {
         this.temp = temp;
-        this.weather = weather;
+        this.weather = MajorWeather.from(weather);
+        this.weatherMessage = this.weather.getMessage();
     }
 }

--- a/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
+++ b/api/src/test/java/com/nexters/gaetteok/walklog/presentation/WalkLogControllerTests.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class WalkLogControllerTests extends AbstractControllerTests {
@@ -242,6 +244,20 @@ public class WalkLogControllerTests extends AbstractControllerTests {
 
         // then
         resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    void delete_correctId_success() throws Exception {
+        // given
+        long id = 1;
+        doNothing().when(walkLogApplication).delete(anyLong(), anyLong());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(delete("/api/walk-logs/{id}", id)
+            .header("Authorization", "Bearer token"));
+
+        // then
+        resultActions.andExpect(status().isNoContent());
     }
 
 }

--- a/domain/walklog/src/main/java/com/nexters/gaetteok/domain/Comment.java
+++ b/domain/walklog/src/main/java/com/nexters/gaetteok/domain/Comment.java
@@ -1,9 +1,10 @@
 package com.nexters.gaetteok.domain;
 
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
 @ToString
@@ -12,6 +13,8 @@ public class Comment {
     private long id;
 
     private String content;
+
+    private long writerId;
 
     private String writerNickname;
 
@@ -22,14 +25,15 @@ public class Comment {
     private LocalDateTime createdAt;
 
     @Builder
-
-    public Comment(long id, String content, String writerNickname, String writerProfileImageUrl,
-        long walkLogId, LocalDateTime createdAt) {
+    public Comment(long id, String content, long writerId, String writerNickname,
+                   String writerProfileImageUrl, long walkLogId, LocalDateTime createdAt) {
         this.id = id;
         this.content = content;
+        this.writerId = writerId;
         this.writerNickname = writerNickname;
         this.writerProfileImageUrl = writerProfileImageUrl;
         this.walkLogId = walkLogId;
         this.createdAt = createdAt;
     }
+
 }

--- a/domain/walklog/src/main/java/com/nexters/gaetteok/domain/Reaction.java
+++ b/domain/walklog/src/main/java/com/nexters/gaetteok/domain/Reaction.java
@@ -1,16 +1,17 @@
 package com.nexters.gaetteok.domain;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reaction {
 
     private long id;
+
+    private long writerId;
 
     private String writerNickname;
 
@@ -23,8 +24,10 @@ public class Reaction {
     private LocalDateTime createdAt;
 
     @Builder
-    public Reaction(long id, String writerNickname, String writerProfileImageUrl, ReactionType reactionType, long walkLogId, LocalDateTime createdAt) {
+    public Reaction(long id, long writerId, String writerNickname, String writerProfileImageUrl,
+                    ReactionType reactionType, long walkLogId, LocalDateTime createdAt) {
         this.id = id;
+        this.writerId = writerId;
         this.writerNickname = writerNickname;
         this.writerProfileImageUrl = writerProfileImageUrl;
         this.reactionType = reactionType;

--- a/domain/walklog/src/main/java/com/nexters/gaetteok/domain/WalkLog.java
+++ b/domain/walklog/src/main/java/com/nexters/gaetteok/domain/WalkLog.java
@@ -21,6 +21,8 @@ public class WalkLog {
 
     private WalkTime walkTime;
 
+    private long writerId;
+
     private String writerNickname;
 
     private String writerProfileImageUrl;
@@ -33,12 +35,13 @@ public class WalkLog {
 
     @Builder
     public WalkLog(long id, String photoUrl, String title, String content, WalkTime walkTime,
-        String writerNickname, String writerProfileImageUrl, LocalDateTime createdAt) {
+                   long writerId, String writerNickname, String writerProfileImageUrl, LocalDateTime createdAt) {
         this.id = id;
         this.photoUrl = photoUrl;
         this.title = title;
         this.content = content;
         this.walkTime = walkTime;
+        this.writerId = writerId;
         this.writerNickname = writerNickname;
         this.writerProfileImageUrl = writerProfileImageUrl;
         this.createdAt = createdAt;

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/CommentEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/CommentEntity.java
@@ -1,18 +1,13 @@
 package com.nexters.gaetteok.persistence.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(
@@ -36,20 +31,20 @@ public class CommentEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "writer_id")
-    private long writerId;
+    @Column(name = "user_id")
+    private long userId;
 
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
-    public CommentEntity(long id, String content, long writerId, long walkLogId,
-        LocalDateTime createdAt) {
+    public CommentEntity(long id, String content, long userId, long walkLogId,
+                         LocalDateTime createdAt) {
         this.id = id;
         this.walkLogId = walkLogId;
         this.content = content;
-        this.writerId = writerId;
+        this.userId = userId;
         this.createdAt = createdAt;
     }
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CommentRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CommentRepository.java
@@ -1,12 +1,12 @@
 package com.nexters.gaetteok.persistence.repository;
 
 import com.nexters.gaetteok.persistence.entity.CommentEntity;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<CommentEntity, Long>, CustomCommentRepository {
 
     List<CommentEntity> findByWalkLogIdIn(List<Long> walkLogIds);
 
-    List<CommentEntity> findByWalkLogId(Long walkLogId);
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepository.java
@@ -1,0 +1,11 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.domain.Comment;
+
+import java.util.List;
+
+public interface CustomCommentRepository {
+
+    List<Comment> findByWalkLogIdInWithUser(long walkLogId);
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.domain.Comment;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.nexters.gaetteok.persistence.entity.QCommentEntity.commentEntity;
+import static com.nexters.gaetteok.persistence.entity.QUserEntity.userEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomCommentRepositoryImpl implements CustomCommentRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Comment> findByWalkLogIdInWithUser(long walkLogId) {
+        return queryFactory.select(Projections.constructor(Comment.class,
+                commentEntity.id,
+                commentEntity.content,
+                userEntity.id,
+                userEntity.nickname,
+                userEntity.profileUrl,
+                commentEntity.walkLogId,
+                commentEntity.createdAt
+            ))
+            .from(commentEntity)
+            .join(userEntity).on(commentEntity.userId.eq(userEntity.id))
+            .where(commentEntity.walkLogId.eq(walkLogId))
+            .orderBy(commentEntity.id.asc())
+            .fetch();
+    }
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepository.java
@@ -1,0 +1,11 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.domain.Reaction;
+
+import java.util.List;
+
+public interface CustomReactionRepository {
+
+    List<Reaction> findByWalkLogIdInWithUser(long walkLogId);
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.nexters.gaetteok.persistence.repository;
+
+import com.nexters.gaetteok.domain.Reaction;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.nexters.gaetteok.persistence.entity.QReactionEntity.reactionEntity;
+import static com.nexters.gaetteok.persistence.entity.QUserEntity.userEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomReactionRepositoryImpl implements CustomReactionRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Reaction> findByWalkLogIdInWithUser(long walkLogId) {
+        return queryFactory.select(Projections.constructor(Reaction.class,
+                reactionEntity.id,
+                userEntity.id,
+                userEntity.nickname,
+                userEntity.profileUrl,
+                reactionEntity.reactionType,
+                reactionEntity.walkLogId,
+                reactionEntity.createdAt
+            ))
+            .from(reactionEntity)
+            .join(userEntity).on(reactionEntity.userId.eq(userEntity.id))
+            .where(reactionEntity.walkLogId.eq(walkLogId))
+            .orderBy(reactionEntity.id.asc())
+            .fetch();
+    }
+
+}

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -51,6 +51,7 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
                 walkLogEntity.title,
                 walkLogEntity.content,
                 walkLogEntity.walkTime,
+                userEntity.id,
                 userEntity.nickname,
                 userEntity.profileUrl,
                 walkLogEntity.createdAt
@@ -76,6 +77,7 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
                 walkLogEntity.title,
                 walkLogEntity.content,
                 walkLogEntity.walkTime,
+                userEntity.id,
                 userEntity.nickname,
                 userEntity.profileUrl,
                 walkLogEntity.createdAt

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/ReactionRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/ReactionRepository.java
@@ -1,10 +1,11 @@
 package com.nexters.gaetteok.persistence.repository;
 
 import com.nexters.gaetteok.persistence.entity.ReactionEntity;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReactionRepository extends JpaRepository<ReactionEntity, Long> {
+import java.util.List;
+
+public interface ReactionRepository extends JpaRepository<ReactionEntity, Long>, CustomReactionRepository {
 
     default ReactionEntity getById(long reactionId) {
         return findById(reactionId)
@@ -13,7 +14,5 @@ public interface ReactionRepository extends JpaRepository<ReactionEntity, Long> 
     }
 
     List<ReactionEntity> findByWalkLogIdIn(List<Long> walkLogIds);
-
-    List<ReactionEntity> findByWalkLogId(Long walkLogId);
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/weather/enums/Weather.java
+++ b/infra/src/main/java/com/nexters/gaetteok/weather/enums/Weather.java
@@ -1,19 +1,33 @@
 package com.nexters.gaetteok.weather.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum Weather {
-    THUNDERSTORM,
-    DRIZZLE,
-    RAIN,
-    SNOW,
-    MIST,
-    SMOKE,
-    HAZE,
-    DUST,
-    FOG,
-    SAND,
-    ASH,
-    SQUALL,
-    TORNADO,
-    CLEAR,
-    CLOUDS
+    THUNDERSTORM("우산을 챙겨주세요"),
+    DRIZZLE("우산을 챙겨주세요"),
+    RAIN("우산을 챙겨주세요"),
+
+    SNOW("눈이 내립니다"),
+
+    SMOKE("연기가 많이 납니다"),
+    ASH("화산재가 날립니다"),
+
+    MIST("안개가 낀 날씨입니다"),
+    HAZE("안개가 낀 날씨입니다"),
+    DUST("미세먼지가 많습니다"),
+    FOG("안개가 낀 날씨입니다"),
+    SAND("모래가 많이 날립니다"),
+    SQUALL("돌풍이 불고 있습니다"),
+    TORNADO("토네이도가 발생했습니다"),
+    CLOUDS("구름이 많이 끼어 있습니다"),
+
+    CLEAR("맑은 날씨입니다");
+
+    private final String message;
+
+    Weather(String message) {
+        this.message = message;
+    }
+
 }


### PR DESCRIPTION
- 피드 상세 조회에서 comment, reaction 사용자 정보를 잘못 조회하고 있던 문제 해결
- 산책기록, 댓글, 리액션 응답에 작성자 아이디와 작성자가 나인지 여부를 추가
- 피드 삭제 API 추가
- 테스트 데이터 보강 (댓글, 리액션 정보 추가)
- 날씨 API의 날씨 응답 타입을 4개로 그룹화