### PR TITLE
Fix sort condition, Update report APIs, Add user soft delete

### DIFF
--- a/api/src/main/java/com/nexters/gaetteok/user/application/UserApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/application/UserApplication.java
@@ -29,6 +29,7 @@ public class UserApplication {
     private final UserRepository userRepository;
     private final UserPushNotificationRepository userPushNotificationRepository;
 
+    private final FriendRepository friendRepository;
     private final WalkLogRepository walkLogRepository;
     private final CommentRepository commentRepository;
     private final ReactionRepository reactionRepository;
@@ -107,11 +108,13 @@ public class UserApplication {
         long userId = userInfo.getUserId();
         UserEntity userEntity = userRepository.getById(userId);
         userEntity.delete();
+        long deletedFriendCount = friendRepository.deleteByUserId(userId);
         long deletedWalkLogCount = walkLogRepository.deleteByUserId(userId);
         long deletedCommentCount = commentRepository.deleteByUserId(userId);
         long deletedReactionCount = reactionRepository.deleteByUserId(userId);
-        log.info("사용자 {} 삭제 - 삭제된 산책 기록 수: {}, 댓글 수: {}, 리액션 수: {}",
+        log.info("사용자 {} 삭제 - 삭제된 친구 관계 수: {}, 산책 기록 수: {}, 댓글 수: {}, 리액션 수: {}",
             userInfo,
+            deletedFriendCount,
             deletedWalkLogCount,
             deletedCommentCount,
             deletedReactionCount
@@ -122,11 +125,13 @@ public class UserApplication {
     public void restoreUser(long userId) {
         UserEntity userEntity = userRepository.getById(userId);
         userEntity.restore();
+        long restoreFriendCount = friendRepository.restoreByUserId(userId);
         long restoredWalkLogCount = walkLogRepository.restoreByUserId(userId);
         long restoredCommentCount = commentRepository.restoreByUserId(userId);
         long restoredReactionCount = reactionRepository.restoreByUserId(userId);
-        log.info("사용자 {} 복구 - 복구된 산책 기록 수: {}, 댓글 수: {}, 리액션 수: {}",
+        log.info("사용자 {} 복구 - 복구된 친구 관계 수: {}, 산책 기록 수: {}, 댓글 수: {}, 리액션 수: {}",
             userId,
+            restoreFriendCount,
             restoredWalkLogCount,
             restoredCommentCount,
             restoredReactionCount

--- a/api/src/main/java/com/nexters/gaetteok/user/application/UserApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/application/UserApplication.java
@@ -4,19 +4,22 @@ import com.nexters.gaetteok.domain.User;
 import com.nexters.gaetteok.domain.UserPushNotification;
 import com.nexters.gaetteok.image.model.File;
 import com.nexters.gaetteok.image.service.ImageUploader;
+import com.nexters.gaetteok.jwt.UserInfo;
 import com.nexters.gaetteok.persistence.entity.UserEntity;
 import com.nexters.gaetteok.persistence.entity.UserPushNotificationEntity;
-import com.nexters.gaetteok.persistence.repository.UserPushNotificationRepository;
-import com.nexters.gaetteok.persistence.repository.UserRepository;
+import com.nexters.gaetteok.persistence.repository.*;
 import com.nexters.gaetteok.user.mapper.UserMapper;
 import com.nexters.gaetteok.user.mapper.UserPushNotificationMapper;
-import java.io.IOException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserApplication {
@@ -25,6 +28,10 @@ public class UserApplication {
 
     private final UserRepository userRepository;
     private final UserPushNotificationRepository userPushNotificationRepository;
+
+    private final WalkLogRepository walkLogRepository;
+    private final CommentRepository commentRepository;
+    private final ReactionRepository reactionRepository;
 
     @Transactional(readOnly = true)
     public User getUser(long id) {
@@ -93,6 +100,37 @@ public class UserApplication {
         userPushNotificationEntity = userPushNotificationRepository.save(
             UserPushNotificationMapper.toEntity(userPushNotification));
         return UserPushNotificationMapper.toDomain(userPushNotificationEntity);
+    }
+
+    @Transactional
+    public void deleteUser(UserInfo userInfo) {
+        long userId = userInfo.getUserId();
+        UserEntity userEntity = userRepository.getById(userId);
+        userEntity.delete();
+        long deletedWalkLogCount = walkLogRepository.deleteByUserId(userId);
+        long deletedCommentCount = commentRepository.deleteByUserId(userId);
+        long deletedReactionCount = reactionRepository.deleteByUserId(userId);
+        log.info("사용자 {} 삭제 - 삭제된 산책 기록 수: {}, 댓글 수: {}, 리액션 수: {}",
+            userInfo,
+            deletedWalkLogCount,
+            deletedCommentCount,
+            deletedReactionCount
+        );
+    }
+
+    @Transactional
+    public void restoreUser(long userId) {
+        UserEntity userEntity = userRepository.getById(userId);
+        userEntity.restore();
+        long restoredWalkLogCount = walkLogRepository.restoreByUserId(userId);
+        long restoredCommentCount = commentRepository.restoreByUserId(userId);
+        long restoredReactionCount = reactionRepository.restoreByUserId(userId);
+        log.info("사용자 {} 복구 - 복구된 산책 기록 수: {}, 댓글 수: {}, 리액션 수: {}",
+            userId,
+            restoredWalkLogCount,
+            restoredCommentCount,
+            restoredReactionCount
+        );
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/UserController.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/UserController.java
@@ -88,4 +88,18 @@ public class UserController implements UserSpecification {
         return ResponseEntity.ok(ReportUserResponse.of(atomicInteger.getAndIncrement(), request.getReason(), LocalDateTime.now()));
     }
 
+    @DeleteMapping(value = "")
+    public ResponseEntity<Void> deleteUser(UserInfo userInfo) {
+        log.info("[유저 삭제] userInfo={}", userInfo);
+        userApplication.deleteUser(userInfo);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping(value = "/restore/{userId}")
+    public ResponseEntity<Void> restoreUser(@PathVariable long userId) {
+        log.info("[유저 복구] userId={}", userId);
+        userApplication.restoreUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/UserController.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/UserController.java
@@ -85,7 +85,7 @@ public class UserController implements UserSpecification {
     public ResponseEntity<ReportUserResponse> reportUser(@RequestBody ReportUserRequest request,
                                                          UserInfo userInfo) {
         log.info("[유저 신고] userInfo={}, request={}", userInfo, request);
-        return ResponseEntity.ok(ReportUserResponse.of(atomicInteger.getAndIncrement(), LocalDateTime.now()));
+        return ResponseEntity.ok(ReportUserResponse.of(atomicInteger.getAndIncrement(), request.getReason(), LocalDateTime.now()));
     }
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/UserSpecification.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/UserSpecification.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -89,7 +90,21 @@ public interface UserSpecification {
     )
     ResponseEntity<ReportUserResponse> reportUser(
         @RequestBody ReportUserRequest request,
-        UserInfo userInfo
+        @Parameter(hidden = true) UserInfo userInfo
     );
+
+    @Operation(summary = "유저 삭제", description = "유저를 삭제하는 API")
+    @ApiResponse(
+        responseCode = "204",
+        description = "유저 삭제 완료"
+    )
+    ResponseEntity<Void> deleteUser(@Parameter(hidden = true) UserInfo userInfo);
+
+    @Operation(summary = "삭제된 유저 복구", description = "삭제된 유저를 복구하는 API")
+    @ApiResponse(
+        responseCode = "204",
+        description = "복구 완료"
+    )
+    ResponseEntity<Void> restoreUser(@PathVariable long userId);
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/user/presentation/response/ReportUserResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/user/presentation/response/ReportUserResponse.java
@@ -12,18 +12,23 @@ public class ReportUserResponse {
     @Schema(description = "신고 ID", example = "1")
     private long id;
 
+    @Schema(description = "신고 사유", example = "욕설")
+    private String reason;
+
     @Schema(description = "신고 시간", example = "2021-08-01T00:00:00")
     private LocalDateTime createdAt;
 
     @Builder
-    public ReportUserResponse(long id, LocalDateTime createdAt) {
+    public ReportUserResponse(long id, String reason, LocalDateTime createdAt) {
         this.id = id;
+        this.reason = reason;
         this.createdAt = createdAt;
     }
 
-    public static ReportUserResponse of(long id, LocalDateTime createdAt) {
+    public static ReportUserResponse of(long id, String reason, LocalDateTime createdAt) {
         return ReportUserResponse.builder()
             .id(id)
+            .reason(reason)
             .createdAt(createdAt)
             .build();
     }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -68,7 +68,9 @@ public class WalkLogApplication {
             .collect(Collectors.groupingBy(Comment::getWalkLogId));
 
         walkLogs.forEach(
-            walkLog -> walkLog.setComments(commentMap.get(walkLog.getId()))
+            walkLog -> walkLog.setComments(commentMap.get(walkLog.getId()).stream()
+                .sorted(Comparator.comparing(Comment::getCreatedAt).reversed())
+                .toList())
         );
     }
 
@@ -92,7 +94,9 @@ public class WalkLogApplication {
             .collect(Collectors.groupingBy(Reaction::getWalkLogId));
 
         walkLogs.forEach(
-            walkLog -> walkLog.setReactions(reactionMap.get(walkLog.getId()))
+            walkLog -> walkLog.setReactions(reactionMap.get(walkLog.getId()).stream()
+                .sorted(Comparator.comparing(Reaction::getCreatedAt))
+                .toList())
         );
     }
 
@@ -139,12 +143,16 @@ public class WalkLogApplication {
 
     @Transactional(readOnly = true)
     public List<WalkLog> getList(long userId, long cursorId, int pageSize) {
-        return walkLogRepository.getListOfMeAndMyFriend(userId, cursorId, pageSize);
+        return walkLogRepository.getListOfMeAndMyFriend(userId, cursorId, pageSize).stream()
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public List<WalkLog> getListById(long userId, long cursorId, int pageSize) {
-        return walkLogRepository.getListOnlyMe(userId, cursorId, pageSize);
+        return walkLogRepository.getListOnlyMe(userId, cursorId, pageSize).stream()
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
+            .toList();
     }
 
     @Transactional(readOnly = true)
@@ -168,6 +176,7 @@ public class WalkLogApplication {
         List<WalkLog> walkLogs = walkLogRepository.getListByUserIdAndMonth(userId, year, month)
             .stream()
             .map(walkLogEntity -> WalkLogMapper.toDomain(walkLogEntity, me))
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
             .toList();
 
         List<Long> walkLogIds = walkLogs.stream()

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/CommentController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/CommentController.java
@@ -4,21 +4,20 @@ import com.nexters.gaetteok.domain.Comment;
 import com.nexters.gaetteok.jwt.UserInfo;
 import com.nexters.gaetteok.walklog.application.CommentApplication;
 import com.nexters.gaetteok.walklog.presentation.request.CreateCommentRequest;
+import com.nexters.gaetteok.walklog.presentation.request.ReportCommentRequest;
 import com.nexters.gaetteok.walklog.presentation.request.UpdateCommentRequest;
 import com.nexters.gaetteok.walklog.presentation.response.CreateCommentResponse;
+import com.nexters.gaetteok.walklog.presentation.response.ReportCommentResponse;
 import com.nexters.gaetteok.walklog.presentation.response.UpdateCommentResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @RestController
@@ -27,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController implements CommentSpecification {
 
     private final CommentApplication commentApplication;
+    private final AtomicInteger atomicInteger = new AtomicInteger(1);
 
     @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CreateCommentResponse> create(
@@ -52,4 +52,12 @@ public class CommentController implements CommentSpecification {
         commentApplication.delete(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping(value = "/comments/report", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ReportCommentResponse> reportComment(@RequestBody ReportCommentRequest request,
+                                                               UserInfo userInfo) {
+        log.info("[댓글 신고] userInfo={}, request={}", userInfo, request);
+        return ResponseEntity.ok(ReportCommentResponse.of(atomicInteger.getAndIncrement(), request.getReason(), LocalDateTime.now()));
+    }
+
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/CommentSpecification.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/CommentSpecification.java
@@ -2,8 +2,10 @@ package com.nexters.gaetteok.walklog.presentation;
 
 import com.nexters.gaetteok.jwt.UserInfo;
 import com.nexters.gaetteok.walklog.presentation.request.CreateCommentRequest;
+import com.nexters.gaetteok.walklog.presentation.request.ReportCommentRequest;
 import com.nexters.gaetteok.walklog.presentation.request.UpdateCommentRequest;
 import com.nexters.gaetteok.walklog.presentation.response.CreateCommentResponse;
+import com.nexters.gaetteok.walklog.presentation.response.ReportCommentResponse;
 import com.nexters.gaetteok.walklog.presentation.response.UpdateCommentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,14 +14,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
 
 @Tag(name = "Comment", description = "댓글 API")
 public interface CommentSpecification {
 
-    @Operation(summary = "댓글 생성", description = "산책 기록에 댓글을 생성합니다.")
+    @Operation(summary = "댓글 생성", description = "산책 기록의 댓글을 생성합니다.")
     @ApiResponse(
         responseCode = "200",
         description = "댓글 생성 성공",
@@ -34,7 +37,7 @@ public interface CommentSpecification {
         @Parameter(hidden = true) UserInfo userInfo
     ) throws IOException;
 
-    @Operation(summary = "댓글 수정", description = "산책 기록에 댓글을 수정합니다.")
+    @Operation(summary = "댓글 수정", description = "산책 기록의 댓글을 수정합니다.")
     @ApiResponse(
         responseCode = "200",
         description = "댓글 수정 성공",
@@ -48,18 +51,28 @@ public interface CommentSpecification {
         @RequestBody UpdateCommentRequest request
     ) throws IOException;
 
-    @Operation(summary = "댓글 삭제", description = "산책 기록에 댓글을 삭제합니다.")
+    @Operation(summary = "댓글 삭제", description = "산책 기록의 댓글을 삭제합니다.")
     @ApiResponse(
         responseCode = "200",
-        description = "댓글 삭제 성공",
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON_VALUE,
-            schema = @Schema(implementation = Void.class)
-        )
+        description = "댓글 삭제 성공"
     )
     ResponseEntity<Void> delete(
         @Parameter(description = "댓글 고유 ID") long id,
         @Parameter(hidden = true) UserInfo userInfo
     ) throws IOException;
+
+    @Operation(summary = "댓글 신고", description = "산책 기록의 댓글을 신고합니다.")
+    @ApiResponse(
+        responseCode = "200",
+        description = "댓글 신고 성공",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = @Schema(implementation = ReportCommentResponse.class)
+        )
+    )
+    ResponseEntity<ReportCommentResponse> reportComment(
+        @RequestBody ReportCommentRequest request,
+        @Parameter(hidden = true) UserInfo userInfo
+    );
 
 }

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -118,12 +118,12 @@ public class WalkLogController implements WalkLogSpecification {
     }
 
     @PostMapping(value = "/report", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ReportWalkLogResponse> reportUser(
+    public ResponseEntity<ReportWalkLogResponse> reportWalkLog(
         @RequestBody ReportWalkLogRequest request,
         UserInfo userInfo) {
-        log.info("[유저 신고] userInfo={}, request={}", userInfo, request);
+        log.info("[산책 기록 신고] userInfo={}, request={}", userInfo, request);
         return ResponseEntity.ok(
-            ReportWalkLogResponse.of(atomicInteger.getAndIncrement(), LocalDateTime.now()));
+            ReportWalkLogResponse.of(atomicInteger.getAndIncrement(), request.getReason(), LocalDateTime.now()));
     }
 
     @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
@@ -4,24 +4,19 @@ import com.nexters.gaetteok.jwt.UserInfo;
 import com.nexters.gaetteok.walklog.presentation.request.CreateWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.PatchWalkLogRequest;
 import com.nexters.gaetteok.walklog.presentation.request.ReportWalkLogRequest;
-import com.nexters.gaetteok.walklog.presentation.response.CreateWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogDetailResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListGroupByMonthResponse;
-import com.nexters.gaetteok.walklog.presentation.response.GetWalkLogListResponse;
-import com.nexters.gaetteok.walklog.presentation.response.PatchWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.ReportWalkLogResponse;
-import com.nexters.gaetteok.walklog.presentation.response.WalkLogCalendarResponse;
+import com.nexters.gaetteok.walklog.presentation.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "WalkLog", description = "산책 기록 API")
 public interface WalkLogSpecification {
@@ -127,7 +122,7 @@ public interface WalkLogSpecification {
             schema = @Schema(implementation = ReportWalkLogResponse.class)
         )
     )
-    ResponseEntity<ReportWalkLogResponse> reportUser(
+    ResponseEntity<ReportWalkLogResponse> reportWalkLog(
         @RequestBody ReportWalkLogRequest request,
         UserInfo userInfo
     );

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
@@ -124,9 +124,8 @@ public interface WalkLogSpecification {
     )
     ResponseEntity<ReportWalkLogResponse> reportWalkLog(
         @RequestBody ReportWalkLogRequest request,
-        UserInfo userInfo
+        @Parameter(hidden = true) UserInfo userInfo
     );
-
 
     @Operation(summary = "산책 기록 상세 조회", description = "산책 기록을 상세 조회합니다.")
     @ApiResponse(

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/request/ReportCommentRequest.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/request/ReportCommentRequest.java
@@ -1,0 +1,22 @@
+package com.nexters.gaetteok.walklog.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReportCommentRequest {
+
+    @Schema(description = "신고 대상 댓글 ID", example = "1")
+    private long reportedCommentId;
+
+    @Schema(description = "신고 사유", example = "욕설")
+    private String reason;
+
+    @Builder
+    public ReportCommentRequest(long reportedCommentId, String reason) {
+        this.reportedCommentId = reportedCommentId;
+        this.reason = reason;
+    }
+
+}

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/ReportCommentResponse.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/response/ReportCommentResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class ReportWalkLogResponse {
+public class ReportCommentResponse {
 
     @Schema(description = "신고 ID", example = "1")
     private long id;
@@ -19,14 +19,14 @@ public class ReportWalkLogResponse {
     private LocalDateTime createdAt;
 
     @Builder
-    public ReportWalkLogResponse(long id, String reason, LocalDateTime createdAt) {
+    public ReportCommentResponse(long id, String reason, LocalDateTime createdAt) {
         this.id = id;
         this.reason = reason;
         this.createdAt = createdAt;
     }
 
-    public static ReportWalkLogResponse of(long id, String reason, LocalDateTime createdAt) {
-        return ReportWalkLogResponse.builder()
+    public static ReportCommentResponse of(long id, String reason, LocalDateTime createdAt) {
+        return ReportCommentResponse.builder()
             .id(id)
             .reason(reason)
             .createdAt(createdAt)

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/CommentEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/CommentEntity.java
@@ -38,13 +38,16 @@ public class CommentEntity {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    private boolean deleted;
+
     @Builder
     public CommentEntity(long id, String content, long userId, long walkLogId,
-                         LocalDateTime createdAt) {
+                         LocalDateTime createdAt, boolean deleted) {
         this.id = id;
         this.walkLogId = walkLogId;
         this.content = content;
         this.userId = userId;
         this.createdAt = createdAt;
+        this.deleted = deleted;
     }
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/FriendEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/FriendEntity.java
@@ -39,12 +39,14 @@ public class FriendEntity {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    private boolean deleted;
     @Builder
-    public FriendEntity(long id, long myUserId, long friendUserId, LocalDateTime createdAt) {
+    public FriendEntity(long id, long myUserId, long friendUserId, LocalDateTime createdAt, boolean deleted) {
         this.id = id;
         this.myUserId = myUserId;
         this.friendUserId = friendUserId;
         this.createdAt = createdAt;
+        this.deleted = deleted;
     }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/ReactionEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/ReactionEntity.java
@@ -38,13 +38,21 @@ public class ReactionEntity {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    private boolean deleted;
+
     @Builder
-    public ReactionEntity(long id, long userId, long walkLogId, ReactionType reactionType, LocalDateTime createdAt) {
+    public ReactionEntity(long id,
+                          long userId,
+                          long walkLogId,
+                          ReactionType reactionType,
+                          LocalDateTime createdAt,
+                          boolean deleted) {
         this.id = id;
         this.userId = userId;
         this.walkLogId = walkLogId;
         this.reactionType = reactionType;
         this.createdAt = createdAt;
+        this.deleted = deleted;
     }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/UserEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/UserEntity.java
@@ -2,22 +2,15 @@ package com.nexters.gaetteok.persistence.entity;
 
 import com.nexters.gaetteok.domain.AuthProvider;
 import com.nexters.gaetteok.weather.enums.City;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user")
@@ -55,10 +48,20 @@ public class UserEntity {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    private boolean deleted;
+
+    public void delete() {
+        this.deleted = true;
+    }
+
+    public void restore() {
+        this.deleted = false;
+    }
+
     @Builder
     public UserEntity(long id, String oauthIdentifier, String deviceToken, String nickname,
         String profileUrl, String code, City city, AuthProvider authProvider,
-        LocalDateTime createdAt) {
+        LocalDateTime createdAt, boolean deleted) {
         this.id = id;
         this.oauthIdentifier = oauthIdentifier;
         this.deviceToken = deviceToken;
@@ -68,6 +71,7 @@ public class UserEntity {
         this.location = city;
         this.provider = authProvider;
         this.createdAt = createdAt;
+        this.deleted = deleted;
     }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/entity/WalkLogEntity.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/entity/WalkLogEntity.java
@@ -45,8 +45,18 @@ public class WalkLogEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    private boolean deleted;
+
     @Builder
-    public WalkLogEntity(long id, String photoUrl, String title, String content, WalkTime walkTime, long userId, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public WalkLogEntity(long id,
+                         String photoUrl,
+                         String title,
+                         String content,
+                         WalkTime walkTime,
+                         long userId,
+                         LocalDateTime createdAt,
+                         LocalDateTime updatedAt,
+                         boolean deleted) {
         this.id = id;
         this.photoUrl = photoUrl;
         this.title = title;
@@ -55,6 +65,7 @@ public class WalkLogEntity {
         this.userId = userId;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.deleted = deleted;
     }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepository.java
@@ -8,4 +8,8 @@ public interface CustomCommentRepository {
 
     List<Comment> findByWalkLogIdInWithUser(long walkLogId);
 
+    long deleteByUserId(long userId);
+
+    long restoreByUserId(long userId);
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepositoryImpl.java
@@ -35,4 +35,22 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
             .fetch();
     }
 
+    @Override
+    public long deleteByUserId(long userId) {
+        return queryFactory
+            .update(commentEntity)
+            .set(commentEntity.deleted, true)
+            .where(commentEntity.userId.eq(userId))
+            .execute();
+    }
+
+    @Override
+    public long restoreByUserId(long userId) {
+        return queryFactory
+            .update(commentEntity)
+            .set(commentEntity.deleted, false)
+            .where(commentEntity.userId.eq(userId))
+            .execute();
+    }
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomCommentRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
             ))
             .from(commentEntity)
             .join(userEntity).on(commentEntity.userId.eq(userEntity.id))
-            .where(commentEntity.walkLogId.eq(walkLogId))
+            .where(commentEntity.walkLogId.eq(walkLogId), commentEntity.deleted.isFalse())
             .orderBy(commentEntity.id.asc())
             .fetch();
     }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepository.java
@@ -9,4 +9,8 @@ public interface CustomFriendRepository {
 
     List<FriendWalkStatus> getFriendWalkStatus(long userId, LocalDate date);
 
+    long deleteByUserId(long userId);
+
+    long restoreByUserId(long userId);
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomFriendRepositoryImpl.java
@@ -47,4 +47,22 @@ public class CustomFriendRepositoryImpl implements CustomFriendRepository {
             .fetch();
     }
 
+    @Override
+    public long deleteByUserId(long userId) {
+        return jpaQueryFactory
+            .update(friendEntity)
+            .set(friendEntity.deleted, true)
+            .where(friendEntity.myUserId.eq(userId), friendEntity.friendUserId.eq(userId))
+            .execute();
+    }
+
+    @Override
+    public long restoreByUserId(long userId) {
+        return jpaQueryFactory
+            .update(friendEntity)
+            .set(friendEntity.deleted, false)
+            .where(friendEntity.myUserId.eq(userId), friendEntity.friendUserId.eq(userId))
+            .execute();
+    }
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepository.java
@@ -8,4 +8,8 @@ public interface CustomReactionRepository {
 
     List<Reaction> findByWalkLogIdInWithUser(long walkLogId);
 
+    long deleteByUserId(long userId);
+
+    long restoreByUserId(long userId);
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepositoryImpl.java
@@ -35,4 +35,22 @@ public class CustomReactionRepositoryImpl implements CustomReactionRepository {
             .fetch();
     }
 
+    @Override
+    public long deleteByUserId(long userId) {
+        return queryFactory
+            .update(reactionEntity)
+            .set(reactionEntity.deleted, true)
+            .where(reactionEntity.userId.eq(userId))
+            .execute();
+    }
+
+    @Override
+    public long restoreByUserId(long userId) {
+        return queryFactory
+            .update(reactionEntity)
+            .set(reactionEntity.deleted, false)
+            .where(reactionEntity.userId.eq(userId))
+            .execute();
+    }
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomReactionRepositoryImpl.java
@@ -30,7 +30,7 @@ public class CustomReactionRepositoryImpl implements CustomReactionRepository {
             ))
             .from(reactionEntity)
             .join(userEntity).on(reactionEntity.userId.eq(userEntity.id))
-            .where(reactionEntity.walkLogId.eq(walkLogId))
+            .where(reactionEntity.walkLogId.eq(walkLogId), reactionEntity.deleted.isFalse())
             .orderBy(reactionEntity.id.asc())
             .fetch();
     }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
@@ -20,4 +20,8 @@ public interface CustomWalkLogRepository {
 
     boolean isTodayWalkLogExists(long walkLogId, LocalDate date);
 
+    long deleteByUserId(long userId);
+
+    long restoreByUserId(long userId);
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -128,5 +128,22 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
         return id != null;
     }
 
+    @Override
+    public long deleteByUserId(long userId) {
+        return jpaQueryFactory
+            .update(walkLogEntity)
+            .set(walkLogEntity.deleted, true)
+            .where(walkLogEntity.userId.eq(userId))
+            .execute();
+    }
+
+    @Override
+    public long restoreByUserId(long userId) {
+        return jpaQueryFactory
+            .update(walkLogEntity)
+            .set(walkLogEntity.deleted, false)
+            .where(walkLogEntity.userId.eq(userId))
+            .execute();
+    }
 
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -29,7 +29,8 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
             .where(
                 walkLogEntity.userId.eq(userId),
                 walkLogEntity.createdAt.after(LocalDateTime.of(year, month, 1, 0, 0)),
-                walkLogEntity.createdAt.before(LocalDateTime.of(year, month + 1, 1, 0, 0))
+                walkLogEntity.createdAt.before(LocalDateTime.of(year, month + 1, 1, 0, 0)),
+                walkLogEntity.deleted.isFalse()
             )
             .fetch();
     }
@@ -39,7 +40,7 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
         List<Long> friendIdList = jpaQueryFactory
             .select(friendEntity.friendUserId)
             .from(friendEntity)
-            .where(friendEntity.myUserId.eq(userId))
+            .where(friendEntity.myUserId.eq(userId), friendEntity.deleted.isFalse())
             .fetch();
         // 피드에는 나도 포함
         friendIdList.add(userId);
@@ -61,7 +62,8 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
             .on(userEntity.id.eq(walkLogEntity.userId))
             .where(
                 cursorId > 0 ? walkLogEntity.id.lt(cursorId) : null,
-                userEntity.id.in(friendIdList)
+                userEntity.id.in(friendIdList),
+                walkLogEntity.deleted.isFalse()
             )
             .limit(pageSize)
             .orderBy(walkLogEntity.id.desc())
@@ -87,7 +89,8 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
             .on(userEntity.id.eq(walkLogEntity.userId))
             .where(
                 cursorId > 0 ? walkLogEntity.id.lt(cursorId) : null,
-                userEntity.id.eq(userId)
+                userEntity.id.eq(userId),
+                walkLogEntity.deleted.isFalse()
             )
             .limit(pageSize)
             .orderBy(walkLogEntity.id.desc())
@@ -100,7 +103,8 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
             .where(
                 walkLogEntity.userId.eq(userId),
                 walkLogEntity.createdAt.year().eq(year),
-                walkLogEntity.createdAt.month().eq(month)
+                walkLogEntity.createdAt.month().eq(month),
+                walkLogEntity.deleted.isFalse()
             )
             .orderBy(walkLogEntity.id.desc())
             .fetch();
@@ -109,7 +113,7 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
     @Override
     public WalkLogEntity getMaxIdLessThan(long walkLogId, long userId) {
         return jpaQueryFactory.selectFrom(walkLogEntity)
-            .where(walkLogEntity.id.lt(walkLogId), walkLogEntity.userId.eq(userId))
+            .where(walkLogEntity.id.lt(walkLogId), walkLogEntity.userId.eq(userId), walkLogEntity.deleted.isFalse())
             .orderBy(walkLogEntity.id.desc())
             .fetchFirst();
     }
@@ -121,7 +125,8 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
             .from(walkLogEntity)
             .where(
                 walkLogEntity.userId.eq(userId),
-                dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date)
+                dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date),
+                walkLogEntity.deleted.isFalse()
             )
             .fetchFirst();
 


### PR DESCRIPTION
- 피드 정렬 기준 정리 (피드-최신순, 댓글-오래된순, 이모지-최신순)
- 사용자 soft delete 추가 (사용자, 산책기록, 댓글, 이모지 모두 deleted 처리됨)
  - 테스트 용이함, 복구 가능성을 고려해 복구 API도 추가
- 댓글 신고 추가

### next
- 신고 실제로 DB에 저장
