### PR TITLE
Fix sort condition of walkLog, comment, reaction

### DIFF
--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -211,6 +211,16 @@ public class WalkLogApplication {
         return walkLogs;
     }
 
+    @Transactional(readOnly = true)
+    public Optional<WalkLog> getTodayWalkLog(long userId) {
+        UserEntity me = userRepository.getById(userId);
+        WalkLogEntity walkLog = walkLogRepository.findRecentWalkLogByUserIdAndDate(userId, LocalDate.now());
+        if (walkLog == null) {
+            return Optional.empty();
+        }
+        return Optional.of(WalkLogMapper.toDomain(walkLog, me));
+    }
+
     public WalkLog getNextData(long walkLogId, long userId) {
         WalkLogEntity entity = walkLogRepository.getMaxIdLessThan(walkLogId, userId);
         if (entity == null) {

--- a/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/application/WalkLogApplication.java
@@ -72,7 +72,8 @@ public class WalkLogApplication {
                 List<Comment> comments = commentMap.get(walkLog.getId());
                 if (comments != null) {
                     walkLog.setComments(comments.stream()
-                        .sorted(Comparator.comparing(Comment::getCreatedAt).reversed())
+                        // 댓글 - 오래된 순으로 정렬
+                        .sorted(Comparator.comparing(Comment::getCreatedAt))
                         .toList());
                 }
             }
@@ -103,7 +104,8 @@ public class WalkLogApplication {
                 List<Reaction> reactions = reactionMap.get(walkLog.getId());
                 if (reactions != null) {
                     walkLog.setReactions(reactions.stream()
-                        .sorted(Comparator.comparing(Reaction::getCreatedAt))
+                        // 리액션 - 최신 순으로 정렬
+                        .sorted(Comparator.comparing(Reaction::getCreatedAt).reversed())
                         .toList());
                 }
             }
@@ -137,7 +139,8 @@ public class WalkLogApplication {
         List<WalkLog> walkLogs = walkLogRepository.getCalendar(userId, year, month)
             .stream()
             .map(walkLogEntity -> WalkLogMapper.toDomain(walkLogEntity, me))
-            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
+            // 산책 기록 - 최신 순으로 정렬
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt).reversed())
             .toList();
 
         Map<String, WalkLog> calendar = new LinkedHashMap<>();
@@ -154,14 +157,16 @@ public class WalkLogApplication {
     @Transactional(readOnly = true)
     public List<WalkLog> getList(long userId, long cursorId, int pageSize) {
         return walkLogRepository.getListOfMeAndMyFriend(userId, cursorId, pageSize).stream()
-            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
+            // 산책 기록 - 최신 순으로 정렬
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt).reversed())
             .toList();
     }
 
     @Transactional(readOnly = true)
     public List<WalkLog> getListById(long userId, long cursorId, int pageSize) {
         return walkLogRepository.getListOnlyMe(userId, cursorId, pageSize).stream()
-            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
+            // 산책 기록 - 최신 순으로 정렬
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt).reversed())
             .toList();
     }
 
@@ -171,8 +176,14 @@ public class WalkLogApplication {
         UserEntity userEntity = userRepository.getById(walkLogEntity.getUserId());
         WalkLog walkLog = WalkLogMapper.toDomain(walkLogEntity, userEntity);
 
-        List<Comment> comments = commentRepository.findByWalkLogIdInWithUser(walkLogId);
-        List<Reaction> reactions = reactionRepository.findByWalkLogIdInWithUser(walkLogId);
+        List<Comment> comments = commentRepository.findByWalkLogIdInWithUser(walkLogId).stream()
+            // 댓글 - 오래된 순으로 정렬
+            .sorted(Comparator.comparing(Comment::getCreatedAt))
+            .toList();
+        List<Reaction> reactions = reactionRepository.findByWalkLogIdInWithUser(walkLogId).stream()
+            // 리액션 - 최신 순으로 정렬
+            .sorted(Comparator.comparing(Reaction::getCreatedAt).reversed())
+            .toList();
 
         walkLog.setComments(comments);
         walkLog.setReactions(reactions);
@@ -186,7 +197,8 @@ public class WalkLogApplication {
         List<WalkLog> walkLogs = walkLogRepository.getListByUserIdAndMonth(userId, year, month)
             .stream()
             .map(walkLogEntity -> WalkLogMapper.toDomain(walkLogEntity, me))
-            .sorted(Comparator.comparing(WalkLog::getCreatedAt))
+            // 산책 기록 - 최신 순으로 정렬
+            .sorted(Comparator.comparing(WalkLog::getCreatedAt).reversed())
             .toList();
 
         List<Long> walkLogIds = walkLogs.stream()

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
@@ -102,6 +103,16 @@ public class WalkLogController implements WalkLogSpecification {
         }
         return ResponseEntity.ok(
             GetWalkLogListGroupByMonthResponse.of(year, month, nextData, walkLogList));
+    }
+
+    @GetMapping(
+        value = "/me/today", produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<GetWalkLogResponse> getMyTodayWalkLog(UserInfo userInfo) {
+        Optional<WalkLog> walkLog = walkLogApplication.getTodayWalkLog(userInfo.getUserId());
+        return walkLog
+            .map(value -> ResponseEntity.ok(GetWalkLogResponse.of(value)))
+            .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     @PatchMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogController.java
@@ -78,8 +78,8 @@ public class WalkLogController implements WalkLogSpecification {
     ) {
         List<WalkLog> walkLogList = walkLogApplication.getListByIdAndMonth(userId, year, month);
         WalkLog nextData = null;
-        if (walkLogList.size() > 0) {
-            WalkLog lastData = walkLogList.get(walkLogList.size() - 1);
+        if (!walkLogList.isEmpty()) {
+            WalkLog lastData = walkLogList.getLast();
             nextData = walkLogApplication.getNextData(lastData.getId(), userId);
         }
         return ResponseEntity.ok(

--- a/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
+++ b/api/src/main/java/com/nexters/gaetteok/walklog/presentation/WalkLogSpecification.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -96,6 +97,23 @@ public interface WalkLogSpecification {
         @Parameter(description = "월") int month,
         @Parameter(hidden = true) UserInfo userInfo
     );
+
+    @Operation(summary = "내 오늘의 산책 기록 조회", description = "내 오늘의 산책 기록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "내 오늘의 산책 기록 존재",
+            content = @Content(
+                mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = GetWalkLogResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "204",
+            description = "내 오늘의 산책 기록 없음"
+        )
+    })
+    ResponseEntity<GetWalkLogResponse> getMyTodayWalkLog(@Parameter(hidden = true) UserInfo userInfo);
 
     @Operation(summary = "산책 기록 변경", description = "산책 기록을 변경합니다.")
     @ApiResponse(

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepository.java
@@ -24,4 +24,6 @@ public interface CustomWalkLogRepository {
 
     long restoreByUserId(long userId);
 
+    WalkLogEntity findRecentWalkLogByUserIdAndDate(long userId, LocalDate date);
+
 }

--- a/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
+++ b/infra/src/main/java/com/nexters/gaetteok/persistence/repository/CustomWalkLogRepositoryImpl.java
@@ -151,4 +151,17 @@ public class CustomWalkLogRepositoryImpl implements CustomWalkLogRepository {
             .execute();
     }
 
+    @Override
+    public WalkLogEntity findRecentWalkLogByUserIdAndDate(long userId, LocalDate date) {
+        return jpaQueryFactory
+            .selectFrom(walkLogEntity)
+            .where(
+                walkLogEntity.userId.eq(userId),
+                dateTimeOperation(LocalDate.class, Ops.DateTimeOps.DATE, walkLogEntity.createdAt).eq(date),
+                walkLogEntity.deleted.isFalse()
+            )
+            .orderBy(walkLogEntity.createdAt.desc())
+            .fetchFirst();
+    }
+
 }


### PR DESCRIPTION
- 산책 기록은 최신순 정렬 (sort createdAt reversed)
- 댓글은 오래된순 정렬 (sort createdAt)
- 리액션은 최신순 정렬 (sort createdAt reversed)

---

- 오늘의 가장 최신 업로드된 산책 기록 조회 API 추가 (없으면 204)